### PR TITLE
Add metric implementation and snapshots

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -20,7 +20,7 @@
 
 package metrics
 
-import "testing"
-
-func TestNothing(t *testing.T) {
+// Controller has the ability to expose the metrics that are registered against
+// the registry this controller was created with.
+type Controller struct {
 }

--- a/controller.go
+++ b/controller.go
@@ -23,4 +23,18 @@ package metrics
 // Controller has the ability to expose the metrics that are registered against
 // the registry this controller was created with.
 type Controller struct {
+	*coreRegistry
+}
+
+func newController(core *coreRegistry) *Controller {
+	return &Controller{
+		coreRegistry: core,
+	}
+}
+
+// Snapshot returns a point-in-time view of all the metrics contained in the
+// controller's registry. It's safe to use concurrently, but is relatively
+// expensive and designed for use in unit tests.
+func (c *Controller) Snapshot() *Snapshot {
+	return c.snapshot()
 }

--- a/core.go
+++ b/core.go
@@ -39,7 +39,7 @@ const _defaultCollectionSize = 128
 // The test suite for metric uniqueness is well-commented and explores the
 // consequences of these two rules.
 type coreRegistry struct {
-	sync.Mutex
+	sync.RWMutex
 
 	dimsByName map[string]string
 	ids        map[string]struct{}
@@ -78,4 +78,15 @@ func (c *coreRegistry) register(m metric) error {
 	c.Unlock()
 
 	return nil
+}
+
+func (c *coreRegistry) snapshot() *Snapshot {
+	c.RLock()
+	defer c.RUnlock()
+	s := &Snapshot{}
+	for _, m := range c.metrics {
+		s.add(m)
+	}
+	s.sort()
+	return s
 }

--- a/core.go
+++ b/core.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"fmt"
+	"sync"
+)
+
+const _defaultCollectionSize = 128
+
+// A coreRegistry is a collection of metrics. Uniqueness is enforced with two
+// checks, just like the vanilla Prometheus client:
+//
+// First, any two metrics with the same name must have the same label names
+// (both constant and variable).
+//
+// Second, no two metrics can share the same name and the same constant label
+// names and values.
+//
+// The test suite for metric uniqueness is well-commented and explores the
+// consequences of these two rules.
+type coreRegistry struct {
+	sync.Mutex
+
+	dimsByName map[string]string
+	ids        map[string]struct{}
+	metrics    []metric
+}
+
+func newCoreRegistry() *coreRegistry {
+	return &coreRegistry{
+		dimsByName: make(map[string]string, _defaultCollectionSize),
+		ids:        make(map[string]struct{}, _defaultCollectionSize),
+		metrics:    make([]metric, 0, _defaultCollectionSize),
+	}
+}
+
+func (c *coreRegistry) register(m metric) error {
+	id := newDigester()
+	defer id.free()
+
+	meta := m.describe()
+	meta.writeID(id)
+
+	c.Lock()
+	if existing, ok := c.dimsByName[*meta.Name]; ok && existing != meta.Dims {
+		c.Unlock()
+		return fmt.Errorf("a metric with name %q and the same label "+
+			"names is already registered", *meta.Name)
+	}
+	if _, ok := c.ids[string(id.digest())]; ok {
+		c.Unlock()
+		return fmt.Errorf("a metric with name %q and the same constant "+
+			"label names and values is already registered", *meta.Name)
+	}
+	c.dimsByName[*meta.Name] = meta.Dims
+	c.ids[string(id.digest())] = struct{}{}
+	c.metrics = append(c.metrics, m)
+	c.Unlock()
+
+	return nil
+}

--- a/core.go
+++ b/core.go
@@ -64,7 +64,7 @@ func (c *coreRegistry) register(m metric) error {
 	c.Lock()
 	if existing, ok := c.dimsByName[*meta.Name]; ok && existing != meta.Dims {
 		c.Unlock()
-		return fmt.Errorf("a metric with name %q and the same label "+
+		return fmt.Errorf("a metric with name %q and different label "+
 			"names is already registered", *meta.Name)
 	}
 	if _, ok := c.ids[string(id.digest())]; ok {

--- a/counter.go
+++ b/counter.go
@@ -29,6 +29,11 @@ import (
 //
 // Nil *Counters are safe no-op implementations.
 type Counter struct {
+	meta metadata
+}
+
+func newCounter(m metadata) *Counter {
+	return &Counter{m}
 }
 
 // Add increases the value of the counter and returns the new value. Since
@@ -57,6 +62,10 @@ func (c *Counter) Load() int64 {
 	return 0
 }
 
+func (c *Counter) describe() metadata {
+	return c.meta
+}
+
 // A CounterVector is a collection of Counters that share a name and some
 // constant labels, but also have a consistent set of variable labels.
 // All exported methods are safe to use concurrently.
@@ -66,6 +75,11 @@ func (c *Counter) Load() int64 {
 // For a general description of vector types, see the package-level
 // documentation.
 type CounterVector struct {
+	meta metadata
+}
+
+func newCounterVector(m metadata) *CounterVector {
+	return &CounterVector{m}
 }
 
 // Get retrieves the counter with the supplied variable label names and values
@@ -91,4 +105,8 @@ func (cv *CounterVector) MustGet(variableLabels ...string) *Counter {
 		panic(fmt.Sprintf("failed to get counter: %v", err))
 	}
 	return c
+}
+
+func (cv *CounterVector) describe() metadata {
+	return cv.meta
 }

--- a/counter.go
+++ b/counter.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"fmt"
+)
+
+// A Counter is a monotonically increasing value, like a car's odometer. All
+// its exported methods are safe to use concurrently.
+//
+// Nil *Counters are safe no-op implementations.
+type Counter struct {
+}
+
+// Add increases the value of the counter and returns the new value. Since
+// counters must be monotonically increasing, passing a negative number just
+// returns the current value (without modifying it).
+func (c *Counter) Add(n int64) int64 {
+	if c == nil {
+		return 0
+	}
+	return 0
+}
+
+// Inc increments the counter's value by one and returns the new value.
+func (c *Counter) Inc() int64 {
+	if c == nil {
+		return 0
+	}
+	return 0
+}
+
+// Load returns the counter's current value.
+func (c *Counter) Load() int64 {
+	if c == nil {
+		return 0
+	}
+	return 0
+}
+
+// A CounterVector is a collection of Counters that share a name and some
+// constant labels, but also have a consistent set of variable labels.
+// All exported methods are safe to use concurrently.
+//
+// A nil *CounterVector is safe to use, and always returns no-op counters.
+//
+// For a general description of vector types, see the package-level
+// documentation.
+type CounterVector struct {
+}
+
+// Get retrieves the counter with the supplied variable label names and values
+// from the vector, creating one if necessary. The variable labels must be
+// supplied in the same order used when creating the vector.
+//
+// Get returns an error if the number or order of labels is incorrect.
+func (cv *CounterVector) Get(variableLabels ...string) (*Counter, error) {
+	if cv == nil {
+		return nil, nil
+	}
+	return nil, nil
+}
+
+// MustGet behaves exactly like Get, but panics on errors. If code using this
+// method is covered by unit tests, this is safe.
+func (cv *CounterVector) MustGet(variableLabels ...string) *Counter {
+	if cv == nil {
+		return nil
+	}
+	c, err := cv.Get(variableLabels...)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get counter: %v", err))
+	}
+	return c
+}

--- a/counter.go
+++ b/counter.go
@@ -66,6 +66,10 @@ func (c *Counter) describe() metadata {
 	return c.meta
 }
 
+func (c *Counter) snapshot() SimpleSnapshot {
+	return SimpleSnapshot{}
+}
+
 // A CounterVector is a collection of Counters that share a name and some
 // constant labels, but also have a consistent set of variable labels.
 // All exported methods are safe to use concurrently.
@@ -109,4 +113,8 @@ func (cv *CounterVector) MustGet(variableLabels ...string) *Counter {
 
 func (cv *CounterVector) describe() metadata {
 	return cv.meta
+}
+
+func (cv *CounterVector) snapshot() []SimpleSnapshot {
+	return nil
 }

--- a/counter.go
+++ b/counter.go
@@ -106,7 +106,7 @@ func (cv *CounterVector) Get(variableLabels ...string) (*Counter, error) {
 	if cv == nil {
 		return nil, nil
 	}
-	m, err := cv.getOrCreate(variableLabels...)
+	m, err := cv.getOrCreate(variableLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/counter_test.go
+++ b/counter_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestCounter(t *testing.T) {
 	r, c := New()
+	r = r.Labeled(Labels{"service": "users"})
 
 	t.Run("duplicate constant label names", func(t *testing.T) {
 		_, err := r.NewCounter(Opts{
@@ -56,7 +57,7 @@ func TestCounter(t *testing.T) {
 		require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
 		assert.Equal(t, SimpleSnapshot{
 			Name:   "test_counter",
-			Labels: Labels{"foo": "bar"},
+			Labels: Labels{"foo": "bar", "service": "users"},
 			Value:  3,
 		}, snap.Counters[0], "Unexpected counter snapshot.")
 	})

--- a/counter_test.go
+++ b/counter_test.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCounter(t *testing.T) {
+	r, c := New()
+
+	t.Run("duplicate constant label names", func(t *testing.T) {
+		_, err := r.NewCounter(Opts{
+			Name:   "test_counter",
+			Help:   "help",
+			Labels: Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate label names
+		})
+		assert.Error(t, err, "Expected an error constructing a counter with invalid options.")
+	})
+
+	t.Run("valid opts", func(t *testing.T) {
+		counter, err := r.NewCounter(Opts{
+			Name:   "test_counter",
+			Help:   "Some help.",
+			Labels: Labels{"foo": "bar"},
+		})
+		require.NoError(t, err, "Unexpected error constructing counter.")
+
+		assert.Equal(t, int64(1), counter.Inc(), "Unexpected return value from increment.")
+		assert.Equal(t, int64(3), counter.Add(2), "Unexpected return value from add.")
+		assert.Equal(t, int64(3), counter.Add(-1), "Should forbid decrementing counters.")
+		assert.Equal(t, int64(3), counter.Load(), "Unexpected in-memory counter value.")
+
+		snap := c.Snapshot()
+		require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
+		assert.Equal(t, SimpleSnapshot{
+			Name:   "test_counter",
+			Labels: Labels{"foo": "bar"},
+			Value:  3,
+		}, snap.Counters[0], "Unexpected counter snapshot.")
+	})
+}
+
+func TestCounterVector(t *testing.T) {
+	newVector := func() (*CounterVector, *Controller) {
+		r, c := New()
+		opts := Opts{
+			Name:           "test_counter",
+			Help:           "Some help.",
+			VariableLabels: []string{"var"},
+		}
+		vec, err := r.NewCounterVector(opts)
+		require.NoError(t, err, "Unexpected error constructing vector.")
+		return vec, c
+	}
+
+	assertCounter := func(c *Controller, expectedLabel string, expectedCount int64) {
+		snap := c.Snapshot()
+		require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
+		got := snap.Counters[0]
+		assert.Equal(t, SimpleSnapshot{
+			Name:   "test_counter",
+			Labels: Labels{"var": expectedLabel},
+			Value:  expectedCount,
+		}, got, "Unexpected counter snapshot.")
+	}
+
+	t.Run("valid labels", func(t *testing.T) {
+		vec, c := newVector()
+		counter, err := vec.Get("var", "x")
+		require.NoError(t, err, "Unexpected error getting counter.")
+
+		counter.Inc()
+		vec.MustGet("var", "x").Add(2)
+
+		assertCounter(c, "x", 3)
+	})
+
+	t.Run("invalid labels", func(t *testing.T) {
+		vec, c := newVector()
+		counter, err := vec.Get("var", "x!")
+		require.NoError(t, err, "Unexpected error getting counter.")
+
+		counter.Inc()
+		vec.MustGet("var", "x!").Inc()
+		vec.MustGet("var", "x&").Inc()
+
+		assertCounter(c, "x_", 3)
+	})
+
+	t.Run("cardinality mismatch", func(t *testing.T) {
+		vec, _ := newVector()
+		_, err := vec.Get("var", "x", "var2", "y")
+		assert.Error(t, err, "Expected an error getting a counter with too many labels.")
+		assert.Panics(t, func() {
+			vec.MustGet("var", "x", "var2", "y")
+		}, "Expected a panic using MustGet with the wrong number of labels.")
+	})
+}
+
+func TestCounterVectorConstructionErrors(t *testing.T) {
+	r, _ := New()
+
+	t.Run("duplicate constant label names", func(t *testing.T) {
+		_, err := r.NewCounterVector(Opts{
+			Name:           "test_counter",
+			Help:           "help",
+			Labels:         Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate label names
+			VariableLabels: []string{"var"},
+		})
+		assert.Error(t, err, "Expected an error constructing a counter vector with invalid options.")
+	})
+
+	t.Run("duplicate variable label names", func(t *testing.T) {
+		_, err := r.NewCounterVector(Opts{
+			Name:           "test_counter",
+			Help:           "help",
+			VariableLabels: []string{"var", "var"},
+		})
+		assert.Error(t, err, "Expected an error constructing a counter vector with invalid options.")
+	})
+}

--- a/gauge.go
+++ b/gauge.go
@@ -81,7 +81,7 @@ func (g *Gauge) Swap(n int64) int64 {
 // indicates whether the swap succeeded.
 func (g *Gauge) CAS(old, new int64) bool {
 	if g == nil {
-		return false
+		return true
 	}
 	return g.val.CAS(old, new)
 }

--- a/gauge.go
+++ b/gauge.go
@@ -98,6 +98,10 @@ func (g *Gauge) describe() metadata {
 	return g.meta
 }
 
+func (g *Gauge) snapshot() SimpleSnapshot {
+	return SimpleSnapshot{}
+}
+
 // A GaugeVector is a collection of Gauges that share a name and some constant
 // labels, but also have a consistent set of variable labels. All exported
 // methods are safe to use concurrently.
@@ -141,4 +145,8 @@ func (gv *GaugeVector) MustGet(variableLabels ...string) *Gauge {
 
 func (gv *GaugeVector) describe() metadata {
 	return gv.meta
+}
+
+func (gv *GaugeVector) snapshot() []SimpleSnapshot {
+	return nil
 }

--- a/gauge.go
+++ b/gauge.go
@@ -138,7 +138,7 @@ func (gv *GaugeVector) Get(variableLabels ...string) (*Gauge, error) {
 	if gv == nil {
 		return nil, nil
 	}
-	m, err := gv.getOrCreate(variableLabels...)
+	m, err := gv.getOrCreate(variableLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/gauge.go
+++ b/gauge.go
@@ -29,6 +29,11 @@ import (
 //
 // Nil *Gauges are safe no-op implementations.
 type Gauge struct {
+	meta metadata
+}
+
+func newGauge(m metadata) *Gauge {
+	return &Gauge{m}
 }
 
 // Add increases the value of the gauge and returns the new value. Adding
@@ -89,6 +94,10 @@ func (g *Gauge) Load() int64 {
 	return 0
 }
 
+func (g *Gauge) describe() metadata {
+	return g.meta
+}
+
 // A GaugeVector is a collection of Gauges that share a name and some constant
 // labels, but also have a consistent set of variable labels. All exported
 // methods are safe to use concurrently.
@@ -98,6 +107,11 @@ func (g *Gauge) Load() int64 {
 // For a general description of vector types, see the package-level
 // documentation.
 type GaugeVector struct {
+	meta metadata
+}
+
+func newGaugeVector(m metadata) *GaugeVector {
+	return &GaugeVector{m}
 }
 
 // Get retrieves the gauge with the supplied variable label names and values
@@ -123,4 +137,8 @@ func (gv *GaugeVector) MustGet(variableLabels ...string) *Gauge {
 		panic(fmt.Sprintf("failed to get gauge: %v", err))
 	}
 	return g
+}
+
+func (gv *GaugeVector) describe() metadata {
+	return gv.meta
 }

--- a/gauge.go
+++ b/gauge.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"fmt"
+)
+
+// A Gauge is a point-in-time measurement, like a car's speedometer. All its
+// exported methods are safe to use concurrently.
+//
+// Nil *Gauges are safe no-op implementations.
+type Gauge struct {
+}
+
+// Add increases the value of the gauge and returns the new value. Adding
+// negative values is allowed, but using Sub may be simpler.
+func (g *Gauge) Add(n int64) int64 {
+	if g == nil {
+		return 0
+	}
+	return 0
+}
+
+// Sub decreases the value of the gauge and returns the new value. Subtracting
+// negative values is allowed, but using Add may be simpler.
+func (g *Gauge) Sub(n int64) int64 {
+	if g == nil {
+		return 0
+	}
+	return 0
+}
+
+// Inc increments the gauge's current value by one and returns the new value.
+func (g *Gauge) Inc() int64 {
+	return g.Add(1)
+}
+
+// Dec decrements the gauge's current value by one and returns the new value.
+func (g *Gauge) Dec() int64 {
+	return g.Sub(1)
+}
+
+// Swap replaces the gauge's current value and returns the previous value.
+func (g *Gauge) Swap(n int64) int64 {
+	if g == nil {
+		return 0
+	}
+	return 0
+}
+
+// CAS is a compare-and-swap. It compares the current value to the old value
+// supplied, and if they match it stores the new value. The return value
+// indicates whether the swap succeeded.
+func (g *Gauge) CAS(old, new int64) bool {
+	if g == nil {
+		return false
+	}
+	return false
+}
+
+// Store changes the gauge's value.
+func (g *Gauge) Store(n int64) {
+}
+
+// Load returns the gauge's current value.
+func (g *Gauge) Load() int64 {
+	if g == nil {
+		return 0
+	}
+	return 0
+}
+
+// A GaugeVector is a collection of Gauges that share a name and some constant
+// labels, but also have a consistent set of variable labels. All exported
+// methods are safe to use concurrently.
+//
+// A nil *GaugeVector is safe to use, and always returns no-op gauges.
+//
+// For a general description of vector types, see the package-level
+// documentation.
+type GaugeVector struct {
+}
+
+// Get retrieves the gauge with the supplied variable label names and values
+// from the vector, creating one if necessary. The variable labels must be
+// supplied in the same order used when creating the vector.
+//
+// Get returns an error if the number or order of labels is incorrect.
+func (gv *GaugeVector) Get(variableLabels ...string) (*Gauge, error) {
+	if gv == nil {
+		return nil, nil
+	}
+	return nil, nil
+}
+
+// MustGet behaves exactly like Get, but panics on errors. If code using this
+// method is covered by unit tests, this is safe.
+func (gv *GaugeVector) MustGet(variableLabels ...string) *Gauge {
+	if gv == nil {
+		return nil
+	}
+	g, err := gv.Get(variableLabels...)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get gauge: %v", err))
+	}
+	return g
+}

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGauge(t *testing.T) {
+	r, c := New()
+	r = r.Labeled(Labels{"service": "users"})
+
+	t.Run("duplicate constant labels", func(t *testing.T) {
+		_, err := r.NewGauge(Opts{
+			Name:   "test_gauge",
+			Help:   "help",
+			Labels: Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate label names
+		})
+		assert.Error(t, err, "Expected an error constructing a gauge with invalid options.")
+	})
+
+	t.Run("valid opts", func(t *testing.T) {
+		gauge, err := r.NewGauge(Opts{
+			Name:   "test_gauge",
+			Help:   "Some help.",
+			Labels: Labels{"foo": "bar"},
+		})
+		require.NoError(t, err, "Unexpected error constructing gauge.")
+
+		assert.Equal(t, int64(1), gauge.Inc(), "Unexpected return value from increment.")
+		assert.Equal(t, int64(0), gauge.Dec(), "Unexpected return value from decrement.")
+		assert.Equal(t, int64(0), gauge.Swap(1), "Unexpected return value from swap.")
+
+		gauge.Store(42)
+		assert.Equal(t, int64(42), gauge.Load(), "Unexpected in-memory gauge value.")
+
+		assert.True(t, gauge.CAS(42, 43), "Unexpected return value from CAS.")
+		snap := c.Snapshot()
+		require.Equal(t, 1, len(snap.Gauges), "Unexpected number of gauges.")
+		assert.Equal(t, SimpleSnapshot{
+			Name:   "test_gauge",
+			Labels: Labels{"foo": "bar", "service": "users"},
+			Value:  43,
+		}, snap.Gauges[0], "Unexpected gauge snapshot.")
+	})
+}
+
+func TestGaugeVector(t *testing.T) {
+	newVector := func() (*GaugeVector, *Controller) {
+		r, c := New()
+		opts := Opts{
+			Name:           "test_gauge",
+			Help:           "Some help.",
+			VariableLabels: []string{"var"},
+		}
+		vec, err := r.NewGaugeVector(opts)
+		require.NoError(t, err, "Unexpected error constructing vector.")
+		return vec, c
+	}
+
+	assertGauge := func(c *Controller, expectedLabel string, expectedReading int64) {
+		snap := c.Snapshot()
+		require.Equal(t, 1, len(snap.Gauges), "Unexpected number of gauges.")
+		got := snap.Gauges[0]
+		assert.Equal(t, "test_gauge", got.Name, "Unexpected name.")
+		assert.Equal(t, Labels{"var": expectedLabel}, got.Labels, "Unexpected labels.")
+		assert.Equal(t, expectedReading, got.Value, "Unexpected gauge value.")
+	}
+
+	t.Run("valid labels", func(t *testing.T) {
+		vec, c := newVector()
+		g, err := vec.Get("var", "x")
+		require.NoError(t, err, "Unexpected error getting gauge.")
+
+		g.Store(1)
+		vec.MustGet("var", "x").Add(2)
+
+		assertGauge(c, "x", 3)
+	})
+
+	t.Run("invalid labels", func(t *testing.T) {
+		vec, c := newVector()
+		g, err := vec.Get("var", "x!")
+		require.NoError(t, err, "Unexpected error getting gauge.")
+
+		g.Store(1)
+		vec.MustGet("var", "x!").Inc()
+		vec.MustGet("var", "x&").Inc()
+
+		assertGauge(c, "x_", 3)
+	})
+
+	t.Run("cardinality mismatch", func(t *testing.T) {
+		vec, _ := newVector()
+		_, err := vec.Get("var", "x", "var2", "y")
+		assert.Error(t, err, "Expected an error getting a gauge with too many labels.")
+		assert.Panics(t, func() {
+			vec.MustGet("var", "x", "var2", "y")
+		}, "Expected a panic using MustGet with the wrong number of labels.")
+	})
+}
+
+func TestGaugeVectorConstructionErrors(t *testing.T) {
+	r, _ := New()
+
+	t.Run("duplicate constant label names", func(t *testing.T) {
+		_, err := r.NewGaugeVector(Opts{
+			Name:           "test_gauge",
+			Help:           "help",
+			Labels:         Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate label names
+			VariableLabels: []string{"var"},
+		})
+		assert.Error(t, err, "Expected an error constructing a gauge vector with invalid options.")
+	})
+
+	t.Run("duplicate variable label names", func(t *testing.T) {
+		_, err := r.NewGaugeVector(Opts{
+			Name:           "test_gauge",
+			Help:           "help",
+			VariableLabels: []string{"var", "var"},
+		})
+		assert.Error(t, err, "Expected an error constructing a gauge vector with invalid options.")
+	})
+}

--- a/histogram.go
+++ b/histogram.go
@@ -54,6 +54,10 @@ func (h *Histogram) describe() metadata {
 	return h.meta
 }
 
+func (h *Histogram) snapshot() HistogramSnapshot {
+	return HistogramSnapshot{}
+}
+
 // A HistogramVector is a collection of Histograms that share a name and some
 // constant labels, but also have a consistent set of variable labels. All
 // exported methods are safe to use concurrently.
@@ -97,4 +101,8 @@ func (hv *HistogramVector) MustGet(variableLabels ...string) *Histogram {
 
 func (hv *HistogramVector) describe() metadata {
 	return hv.meta
+}
+
+func (hv *HistogramVector) snapshot() []HistogramSnapshot {
+	return nil
 }

--- a/histogram.go
+++ b/histogram.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"fmt"
+	"time"
+)
+
+// A Histogram approximates a distribution of values. They're both more
+// efficient and easier to aggregate than Prometheus summaries or M3 timers.
+// For a discussion of the tradeoffs between histograms and timers/summaries,
+// see https://prometheus.io/docs/practices/histograms/.
+//
+// All exported methods are safe to use concurrently, and nil *Histograms are
+// valid no-op implementations.
+type Histogram struct {
+}
+
+// Observe finds the correct bucket for the supplied duration and increments
+// its counter.
+func (h *Histogram) Observe(d time.Duration) {
+}
+
+// ObserveInt finds the correct bucket for the supplied integer and increments
+// its counter.
+func (h *Histogram) ObserveInt(n int64) {
+}
+
+// A HistogramVector is a collection of Histograms that share a name and some
+// constant labels, but also have a consistent set of variable labels. All
+// exported methods are safe to use concurrently.
+//
+// A nil *HistogramVector is safe to use, and always returns no-op histograms.
+//
+// For a general description of vector types, see the package-level
+// documentation.
+type HistogramVector struct {
+}
+
+// Get retrieves the histogram with the supplied variable label names and
+// values from the vector, creating one if necessary. The variable labels must
+// be supplied in the same order used when creating the vector.
+//
+// Get returns an error if the number or order of labels is incorrect.
+func (hv *HistogramVector) Get(variableLabels ...string) (*Histogram, error) {
+	if hv == nil {
+		return nil, nil
+	}
+	return nil, nil
+}
+
+// MustGet behaves exactly like Get, but panics on errors. If code using this
+// method is covered by unit tests, this is safe.
+func (hv *HistogramVector) MustGet(variableLabels ...string) *Histogram {
+	if hv == nil {
+		return nil
+	}
+	h, err := hv.Get(variableLabels...)
+	if err != nil {
+		panic(fmt.Sprintf("failed to get histogram: %v", err))
+	}
+	return h
+}

--- a/histogram.go
+++ b/histogram.go
@@ -33,6 +33,11 @@ import (
 // All exported methods are safe to use concurrently, and nil *Histograms are
 // valid no-op implementations.
 type Histogram struct {
+	meta metadata
+}
+
+func newHistogram(m metadata) *Histogram {
+	return &Histogram{m}
 }
 
 // Observe finds the correct bucket for the supplied duration and increments
@@ -45,6 +50,10 @@ func (h *Histogram) Observe(d time.Duration) {
 func (h *Histogram) ObserveInt(n int64) {
 }
 
+func (h *Histogram) describe() metadata {
+	return h.meta
+}
+
 // A HistogramVector is a collection of Histograms that share a name and some
 // constant labels, but also have a consistent set of variable labels. All
 // exported methods are safe to use concurrently.
@@ -54,6 +63,11 @@ func (h *Histogram) ObserveInt(n int64) {
 // For a general description of vector types, see the package-level
 // documentation.
 type HistogramVector struct {
+	meta metadata
+}
+
+func newHistogramVector(m metadata) *HistogramVector {
+	return &HistogramVector{m}
 }
 
 // Get retrieves the histogram with the supplied variable label names and
@@ -79,4 +93,8 @@ func (hv *HistogramVector) MustGet(variableLabels ...string) *Histogram {
 		panic(fmt.Sprintf("failed to get histogram: %v", err))
 	}
 	return h
+}
+
+func (hv *HistogramVector) describe() metadata {
+	return hv.meta
 }

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHistogram(t *testing.T) {
+	r, c := New()
+	r = r.Labeled(Labels{"service": "users"})
+
+	t.Run("duplicate constant label names", func(t *testing.T) {
+		_, err := r.NewHistogram(HistogramOpts{
+			Opts: Opts{
+				Name:   "test_latency_ns",
+				Help:   "Some help.",
+				Labels: Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate names
+			},
+			Unit:    time.Nanosecond,
+			Buckets: []int64{10, 50, 100},
+		})
+		assert.Error(t, err, "Expected an error constructing a histogram with invalid options.")
+	})
+
+	t.Run("valid opts", func(t *testing.T) {
+		h, err := r.NewHistogram(HistogramOpts{
+			Opts: Opts{
+				Name:   "test_latency_ns",
+				Help:   "Some help.",
+				Labels: Labels{"foo": "bar"},
+			},
+			Unit:    time.Nanosecond,
+			Buckets: []int64{10, 50, 100},
+		})
+		require.NoError(t, err, "Unexpected construction error.")
+
+		h.Observe(-1)
+		h.ObserveInt(0)
+		h.Observe(10)
+		h.ObserveInt(75)
+		h.Observe(150)
+
+		snap := c.Snapshot()
+		require.Equal(t, 1, len(snap.Histograms), "Unexpected number of histogram snapshots.")
+		got := snap.Histograms[0]
+		assert.Equal(t, HistogramSnapshot{
+			Unit:   time.Nanosecond,
+			Name:   "test_latency_ns",
+			Labels: Labels{"foo": "bar", "service": "users"},
+			Values: []int64{10, 10, 10, 100, math.MaxInt64},
+		}, got, "Unexpected histogram snapshot.")
+	})
+}
+
+func TestHistogramVector(t *testing.T) {
+	tests := []struct {
+		desc string
+		opts HistogramOpts
+		f    func(testing.TB, *Registry, HistogramOpts)
+		want HistogramSnapshot
+	}{
+		{
+			desc: "valid labels",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "test_latency_ms",
+					Help:           "Some help.",
+					VariableLabels: []string{"var"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			f: func(t testing.TB, r *Registry, opts HistogramOpts) {
+				vec, err := r.NewHistogramVector(opts)
+				require.NoError(t, err, "Unexpected error constructing vector.")
+				h, err := vec.Get("var", "x")
+				require.NoError(t, err, "Unexpected error getting a counter with correct number of labels.")
+				h.Observe(time.Millisecond)
+				vec.MustGet("var", "x").Observe(time.Millisecond)
+			},
+			want: HistogramSnapshot{
+				Name:   "test_latency_ms",
+				Labels: Labels{"var": "x"},
+				Unit:   time.Millisecond,
+				Values: []int64{1000, 1000},
+			},
+		},
+		{
+			desc: "invalid labels",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "test_latency_ms",
+					Help:           "Some help.",
+					VariableLabels: []string{"var"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			f: func(t testing.TB, r *Registry, opts HistogramOpts) {
+				vec, err := r.NewHistogramVector(opts)
+				require.NoError(t, err, "Unexpected error constructing vector.")
+				h, err := vec.Get("var", "x!")
+				require.NoError(t, err, "Unexpected error getting a counter with correct number of labels.")
+				h.Observe(time.Millisecond)
+				vec.MustGet("var", "x!").Observe(time.Millisecond)
+			},
+			want: HistogramSnapshot{
+				Name:   "test_latency_ms",
+				Labels: Labels{"var": "x_"},
+				Unit:   time.Millisecond,
+				Values: []int64{1000, 1000},
+			},
+		},
+		{
+			desc: "wrong number of label values",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "test_latency_ms",
+					Help:           "Some help.",
+					VariableLabels: []string{"var"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			f: func(t testing.TB, r *Registry, opts HistogramOpts) {
+				vec, err := r.NewHistogramVector(opts)
+				require.NoError(t, err, "Unexpected error constructing vector.")
+				_, err = vec.Get("var", "x", "var2", "y")
+				require.Error(t, err, "Unexpected success calling Get with incorrect number of labels.")
+				require.Panics(
+					t,
+					func() { vec.MustGet("var", "x", "var2", "y") },
+					"Expected a panic using MustGet with the wrong number of labels.",
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			r, c := New()
+			tt.f(t, r, tt.opts)
+			snap := c.Snapshot()
+			if tt.want.Name != "" {
+				require.Equal(t, 1, len(snap.Histograms), "Unexpected number of histogram snapshots.")
+				assert.Equal(t, tt.want, snap.Histograms[0], "Unexpected histogram snapshot.")
+			} else {
+				require.Equal(t, 0, len(snap.Histograms), "Expected no histogram snapshots.")
+			}
+		})
+	}
+}
+
+func TestHistogramVectorIndependence(t *testing.T) {
+	// Ensure that we're not erroneously sharing state across histograms in a
+	// vector.
+	r, c := New()
+	opts := HistogramOpts{
+		Opts: Opts{
+			Name:           "test_latency_ms",
+			Help:           "Some help.",
+			VariableLabels: []string{"var"},
+		},
+		Unit:    time.Millisecond,
+		Buckets: []int64{1000},
+	}
+	vec, err := r.NewHistogramVector(opts)
+	require.NoError(t, err, "Unexpected error constructing vector.")
+
+	x, err := vec.Get("var", "x")
+	require.NoError(t, err, "Unexpected error calling Get.")
+
+	y, err := vec.Get("var", "y")
+	require.NoError(t, err, "Unexpected error calling Get.")
+
+	x.Observe(time.Millisecond)
+	y.Observe(time.Millisecond)
+
+	snap := c.Snapshot()
+	require.Equal(t, 2, len(snap.Histograms), "Unexpected number of histogram snapshots.")
+
+	assert.Equal(t, HistogramSnapshot{
+		Name:   "test_latency_ms",
+		Labels: Labels{"var": "x"},
+		Unit:   time.Millisecond,
+		Values: []int64{1000},
+	}, snap.Histograms[0], "Unexpected first histogram snapshot.")
+	assert.Equal(t, HistogramSnapshot{
+		Name:   "test_latency_ms",
+		Labels: Labels{"var": "y"},
+		Unit:   time.Millisecond,
+		Values: []int64{1000},
+	}, snap.Histograms[1], "Unexpected second histogram snapshot.")
+}

--- a/labels.go
+++ b/labels.go
@@ -269,24 +269,3 @@ func scrubLabelValue(s string) string {
 	d.free()
 	return scrubbed
 }
-
-func areValidLabelValues(ss []string) bool {
-	for _, s := range ss {
-		if !IsValidLabelValue(s) {
-			return false
-		}
-	}
-	return true
-}
-
-func scrubLabelValues(ss []string) []string {
-	if areValidLabelValues(ss) {
-		return ss
-	}
-
-	scrubbed := make([]string, len(ss))
-	for i, dirty := range ss {
-		scrubbed[i] = scrubLabelValue(dirty)
-	}
-	return scrubbed
-}

--- a/labels.go
+++ b/labels.go
@@ -22,7 +22,6 @@ package metrics
 
 import (
 	"bytes"
-	"errors"
 	"sort"
 	"sync"
 
@@ -37,14 +36,9 @@ const (
 	DefaultLabelValue = "default"
 )
 
-var (
-	// Match the Prometheus error message.
-	errInconsistentCardinality = errors.New("inconsistent label cardinality")
-
-	_digesterPool = sync.Pool{New: func() interface{} {
-		return &digester{make([]byte, 0, 128)}
-	}}
-)
+var _digesterPool = sync.Pool{New: func() interface{} {
+	return &digester{make([]byte, 0, 128)}
+}}
 
 // A digester creates a null-delimited byte slice from a series of variable
 // label values. It's an efficient way to create map keys from metric names and

--- a/metadata.go
+++ b/metadata.go
@@ -131,7 +131,7 @@ func (m metadata) ValidateVariableLabels(variableLabels []string) error {
 	for i, expected := range m.variableLabelNames { // user-supplied order was preserved
 		if expected != variableLabels[i*2] {
 			return fmt.Errorf(
-				"variable label %d doesn't match vector definition: expected %s, got %s",
+				"variable label #%d doesn't match vector definition: expected %s, got %s",
 				i,
 				expected,
 				variableLabels[i*2],

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"fmt"
+	"sort"
+
+	promproto "github.com/prometheus/client_model/go"
+)
+
+// metadata stores our internal representation of metric options. Adding this
+// layer of indirection between the user-facing options and the metric
+// constructors serves two purposes: it centralizes the logic for calculating
+// a variety of derived values, and it lets the remainder of the package
+// assume that all user-supplied data has already been fully validated.
+type metadata struct {
+	Name, Help  *string // proto wants pointers
+	Dims        string
+	DisablePush bool
+
+	constPairs         []*promproto.LabelPair
+	variableLabelNames []string // unscrubbed
+}
+
+func newMetadata(o Opts) (metadata, error) {
+	// TODO: Consider checking for duplicate labels with Bloom filters,
+	// allocating maps only if we suspect a duplicate.
+	sortedConstNames := make([]string, 0, len(o.Labels))
+	for k := range o.Labels {
+		sortedConstNames = append(sortedConstNames, k)
+	}
+	sort.Strings(sortedConstNames)
+
+	constNameSet := make(map[string]struct{}, len(sortedConstNames))
+	sortedScrubbedConstNames := make([]string, len(sortedConstNames))
+	sortedScrubbedConstVals := make([]string, len(sortedConstNames))
+	for i, name := range sortedConstNames {
+		scrubbedName := scrubName(name)
+		if _, ok := constNameSet[scrubbedName]; ok {
+			return metadata{}, fmt.Errorf("duplicate constant label name %q", scrubbedName)
+		}
+		constNameSet[scrubbedName] = struct{}{}
+		sortedScrubbedConstNames[i] = scrubbedName
+		sortedScrubbedConstVals[i] = scrubLabelValue(o.Labels[name])
+	}
+
+	varNameSet := make(map[string]struct{}, len(o.VariableLabels))
+	sortedScrubbedVarNames := make([]string, len(o.VariableLabels))
+	for i, name := range o.VariableLabels {
+		scrubbedName := scrubName(name)
+		if _, ok := varNameSet[scrubbedName]; ok {
+			return metadata{}, fmt.Errorf("duplicate variable label name %q", scrubbedName)
+		}
+		varNameSet[scrubbedName] = struct{}{}
+		sortedScrubbedVarNames[i] = scrubbedName
+	}
+	sort.Strings(sortedScrubbedVarNames)
+
+	var pairs []*promproto.LabelPair
+	if len(sortedScrubbedConstNames) > 0 {
+		pairs = make([]*promproto.LabelPair, 0, len(sortedScrubbedConstNames))
+		for i := range sortedScrubbedConstNames {
+			pairs = append(pairs, &promproto.LabelPair{
+				Name:  &sortedScrubbedConstNames[i],
+				Value: &sortedScrubbedConstVals[i],
+			})
+		}
+	}
+	scrubbedName := scrubName(o.Name)
+	return metadata{
+		Name:               &scrubbedName,
+		Help:               &o.Help,
+		Dims:               makeDims(scrubbedName, sortedScrubbedConstNames, sortedScrubbedVarNames),
+		DisablePush:        o.DisablePush,
+		constPairs:         pairs,
+		variableLabelNames: o.VariableLabels, // preserve user-defined order
+	}, nil
+}
+
+// writeID writes the metric's ID to the supplied digester. Since we only use
+// IDs as map keys, we can save an allocation on metric creation by not
+// allocating a string for each ID.
+func (m metadata) writeID(d *digester) {
+	d.add("", *m.Name)
+	for _, pair := range m.constPairs {
+		d.add("", pair.GetName())
+		d.add("", pair.GetValue())
+	}
+}
+
+// makeDims creates a string representation of the metric's dimensions (name,
+// constant label names, and variable label names). It's used as a map value,
+// so we can't avoid this allocation.
+func makeDims(name string, constNames, sortedVarNames []string) string {
+	d := newDigester()
+	d.add("", name)
+	for _, n := range constNames {
+		d.add("", n)
+	}
+	for _, n := range sortedVarNames {
+		// To make sure that we can tell whether a given label name is constant or
+		// variable, prefix variable label names with a character that's otherwise
+		// forbidden.
+		d.add("$", n)
+	}
+	dims := string(d.digest())
+	d.free()
+	return dims
+}

--- a/metadata.go
+++ b/metadata.go
@@ -74,6 +74,9 @@ func newMetadata(o Opts) (metadata, error) {
 		if _, ok := varNameSet[scrubbedName]; ok {
 			return metadata{}, fmt.Errorf("duplicate variable label name %q", scrubbedName)
 		}
+		if _, ok := constNameSet[scrubbedName]; ok {
+			return metadata{}, fmt.Errorf("variable label name %q is also a constant label name", scrubbedName)
+		}
 		varNameSet[scrubbedName] = struct{}{}
 		sortedScrubbedVarNames[i] = scrubbedName
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+// New constructs a base Registry and a Controller.
+func New() (*Registry, *Controller) {
+	return newRegistry(Labels{}), nil
+}

--- a/metrics.go
+++ b/metrics.go
@@ -20,7 +20,12 @@
 
 package metrics
 
-// New constructs a base Registry and a Controller.
+// New constructs a Registry and Controller.
 func New() (*Registry, *Controller) {
-	return newRegistry(Labels{}), nil
+	core := newCoreRegistry()
+	return newRegistry(core, Labels{}), nil
+}
+
+type metric interface {
+	describe() metadata
 }

--- a/metrics.go
+++ b/metrics.go
@@ -23,7 +23,7 @@ package metrics
 // New constructs a Registry and Controller.
 func New() (*Registry, *Controller) {
 	core := newCoreRegistry()
-	return newRegistry(core, Labels{}), nil
+	return newRegistry(core, Labels{}), newController(core)
 }
 
 type metric interface {

--- a/nop_test.go
+++ b/nop_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNopCounter(t *testing.T) {
+	assertNopCounter(t, nil)
+}
+
+func TestNopCounterVector(t *testing.T) {
+	assertNopCounterVector(t, nil)
+}
+
+func TestNopGauge(t *testing.T) {
+	assertNopGauge(t, nil)
+}
+
+func TestNopGaugeVector(t *testing.T) {
+	assertNopGaugeVector(t, nil)
+}
+
+func TestNopHistogram(t *testing.T) {
+	assertNopHistogram(t, nil)
+}
+
+func TestNopHistogramVector(t *testing.T) {
+	assertNopHistogramVector(t, nil)
+}
+
+func TestNopRegistry(t *testing.T) {
+	var r *Registry
+	c, err := r.NewCounter(Opts{})
+	assert.NoError(t, err, "Error calling NewCounter on nil Registry.")
+	assertNopCounter(t, c)
+
+	cv, err := r.NewCounterVector(Opts{})
+	assert.NoError(t, err, "Error calling NewCounterVector on nil Registry.")
+	assertNopCounterVector(t, cv)
+
+	g, err := r.NewGauge(Opts{})
+	assert.NoError(t, err, "Error calling NewGauge on nil Registry.")
+	assertNopGauge(t, g)
+
+	gv, err := r.NewGaugeVector(Opts{})
+	assert.NoError(t, err, "Error calling NewGaugeVector on nil Registry.")
+	assertNopGaugeVector(t, gv)
+
+	h, err := r.NewHistogram(HistogramOpts{})
+	assert.NoError(t, err, "Error calling NewHistogram on nil Registry.")
+	assertNopHistogram(t, h)
+
+	hv, err := r.NewHistogramVector(HistogramOpts{})
+	assertNopHistogramVector(t, hv)
+}
+
+func assertNopCounter(t testing.TB, c *Counter) {
+	assert.Equal(t, int64(0), c.Add(42), "Unexpected result from no-op Add.")
+	assert.Equal(t, int64(0), c.Inc(), "Unexpected result from no-op Inc.")
+	assert.Equal(t, int64(0), c.Load(), "Unexpected result from no-op Load.")
+}
+
+func assertNopCounterVector(t *testing.T, vec *CounterVector) {
+	c, err := vec.Get("foo", "bar")
+	require.NoError(t, err, "Failed Get from no-op CounterVector.")
+	assert.NotPanics(t, func() {
+		vec.MustGet("foo", "bar")
+	}, "Failed MustGet from no-op CounterVector.")
+	assertNopCounter(t, c)
+}
+
+func assertNopGauge(t testing.TB, g *Gauge) {
+	g.Store(42)
+	assert.Equal(t, int64(0), g.Add(42), "Unexpected result from no-op Add.")
+	assert.Equal(t, int64(0), g.Sub(1), "Unexpected result from no-op Sub.")
+	assert.Equal(t, int64(0), g.Inc(), "Unexpected result from no-op Inc.")
+	assert.Equal(t, int64(0), g.Dec(), "Unexpected result from no-op Dec.")
+	assert.Equal(t, int64(0), g.Load(), "Unexpected result from no-op Load.")
+	assert.Equal(t, int64(0), g.Swap(42), "Unexpected result from no-op Swap.")
+	assert.False(t, g.CAS(42, 10), "Unexpected result from no-op CAS.")
+}
+
+func assertNopGaugeVector(t testing.TB, vec *GaugeVector) {
+	g, err := vec.Get("foo", "bar")
+	require.NoError(t, err, "Failed Get from no-op GaugeVector.")
+	assert.NotPanics(t, func() {
+		vec.MustGet("foo", "bar")
+	}, "Failed MustGet from no-op GaugeVector.")
+	assertNopGauge(t, g)
+}
+
+func assertNopHistogram(t testing.TB, h *Histogram) {
+	assert.NotPanics(t, func() {
+		h.Observe(time.Second)
+		h.ObserveInt(42)
+	}, "Unexpected panic using no-op histgram.")
+}
+
+func assertNopHistogramVector(t testing.TB, vec *HistogramVector) {
+	h, err := vec.Get("foo", "bar")
+	require.NoError(t, err, "Failed Get from no-op HistogramVector.")
+	assert.NotPanics(t, func() {
+		vec.MustGet("foo", "bar")
+	}, "Failed MustGet from no-op HistogramVector.")
+	assertNopHistogram(t, h)
+}

--- a/nop_test.go
+++ b/nop_test.go
@@ -102,7 +102,7 @@ func assertNopGauge(t testing.TB, g *Gauge) {
 	assert.Equal(t, int64(0), g.Dec(), "Unexpected result from no-op Dec.")
 	assert.Equal(t, int64(0), g.Load(), "Unexpected result from no-op Load.")
 	assert.Equal(t, int64(0), g.Swap(42), "Unexpected result from no-op Swap.")
-	assert.False(t, g.CAS(42, 10), "Unexpected result from no-op CAS.")
+	assert.True(t, g.CAS(42, 10), "Unexpected result from no-op CAS.")
 }
 
 func assertNopGaugeVector(t testing.TB, vec *GaugeVector) {

--- a/nop_test.go
+++ b/nop_test.go
@@ -54,6 +54,7 @@ func TestNopHistogramVector(t *testing.T) {
 
 func TestNopRegistry(t *testing.T) {
 	var r *Registry
+	r = r.Labeled(Labels{"foo": "bar"})
 	c, err := r.NewCounter(Opts{})
 	assert.NoError(t, err, "Error calling NewCounter on nil Registry.")
 	assertNopCounter(t, c)

--- a/opts.go
+++ b/opts.go
@@ -1,0 +1,114 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+)
+
+// Opts configure Counters, Gauges, CounterVectors, and GaugeVectors.
+type Opts struct {
+	Name           string
+	Help           string
+	Labels         Labels
+	VariableLabels []string // only meaningful for vectors
+	DisablePush    bool
+}
+
+func (o Opts) validate() error {
+	if len(o.Name) == 0 {
+		return errors.New("all metrics must have a name")
+	}
+	if o.Help == "" {
+		return errors.New("metric help must not be empty")
+	}
+	return nil
+}
+
+func (o Opts) validateScalar() error {
+	if err := o.validate(); err != nil {
+		return err
+	}
+	if len(o.VariableLabels) > 0 {
+		return errors.New("only vectors may have variable labels")
+	}
+	return nil
+}
+
+func (o Opts) validateVector() error {
+	if err := o.validate(); err != nil {
+		return err
+	}
+	if len(o.VariableLabels) == 0 {
+		return errors.New("vectors must have variable labels")
+	}
+	return nil
+}
+
+// HistogramOpts configure Histograms and HistogramVectors.
+type HistogramOpts struct {
+	Opts
+
+	// Durations are exported to Prometheus as simple numbers, not strings or
+	// rich objects. Unit specifies the desired granularity for latency
+	// observations. For example, an observation of time.Second with a unit of
+	// time.Millisecond is exported to Prometheus as 1000. Typically, the unit
+	// should also be part of the metric name; in this example, latency_ms is a
+	// good name.
+	Unit time.Duration
+	// Upper bounds (inclusive) for the histogram buckets. A catch-all bucket
+	// for large observations is automatically created, if necessary.
+	Buckets []int64
+}
+
+func (ho HistogramOpts) validateScalar() error {
+	if err := ho.validateLatencies(); err != nil {
+		return err
+	}
+	return ho.Opts.validateScalar()
+}
+
+func (ho HistogramOpts) validateVector() error {
+	if err := ho.validateLatencies(); err != nil {
+		return err
+	}
+	return ho.Opts.validateVector()
+}
+
+func (ho HistogramOpts) validateLatencies() error {
+	if ho.Unit < 1 {
+		return fmt.Errorf("duration unit must be positive, got %v", ho.Unit)
+	}
+	if len(ho.Buckets) == 0 {
+		return fmt.Errorf("must specify some buckets")
+	}
+	prev := int64(math.MinInt64)
+	for _, upper := range ho.Buckets {
+		if upper <= prev {
+			return fmt.Errorf("bucket upper bounds must be sorted in increasing order")
+		}
+		prev = upper
+	}
+	return nil
+}

--- a/opts_test.go
+++ b/opts_test.go
@@ -1,0 +1,424 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptsValidation(t *testing.T) {
+	tests := []struct {
+		desc     string
+		opts     Opts
+		scalarOK bool
+		vecOK    bool
+	}{
+		{
+			desc: "valid names",
+			opts: Opts{
+				Name: "fOo123",
+				Help: "Some help.",
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "valid names & constant labels",
+			opts: Opts{
+				Name:   "foo",
+				Help:   "Some help.",
+				Labels: Labels{"foo": "bar"},
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "name with Tally-forbidden characters",
+			opts: Opts{
+				Name: "foo:bar",
+				Help: "Some help.",
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "no name",
+			opts: Opts{
+				Help: "Some help.",
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
+		{
+			desc: "no help",
+			opts: Opts{
+				Name: "foo",
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
+		{
+			desc: "valid names but invalid label key",
+			opts: Opts{
+				Name:   "foo",
+				Help:   "Some help.",
+				Labels: Labels{"foo:foo": "bar"},
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "valid names but invalid label value",
+			opts: Opts{
+				Name:   "foo",
+				Help:   "Some help.",
+				Labels: Labels{"foo": "bar:bar"},
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "valid names & variable labels",
+			opts: Opts{
+				Name:           "foo",
+				Help:           "Some help.",
+				VariableLabels: []string{"baz"},
+			},
+			scalarOK: false,
+			vecOK:    true,
+		},
+		{
+			desc: "valid names, constant labels, & variable labels",
+			opts: Opts{
+				Name:           "foo",
+				Help:           "Some help.",
+				Labels:         Labels{"foo": "bar"},
+				VariableLabels: []string{"baz"},
+			},
+			scalarOK: false,
+			vecOK:    true,
+		},
+		{
+			desc: "valid names & constant labels, but invalid variable labels",
+			opts: Opts{
+				Name:           "foo",
+				Help:           "Some help.",
+				Labels:         Labels{"foo": "bar"},
+				VariableLabels: []string{"baz:baz"},
+			},
+			scalarOK: false,
+			vecOK:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if tt.scalarOK {
+				assertScalarOptsOK(t, tt.opts)
+			} else {
+				assertScalarOptsFail(t, tt.opts)
+			}
+			if tt.vecOK {
+				assertVectorOptsOK(t, tt.opts)
+			} else {
+				assertVectorOptsFail(t, tt.opts)
+			}
+		})
+	}
+}
+
+func TestHistogramOptsValidation(t *testing.T) {
+	tests := []struct {
+		desc     string
+		opts     HistogramOpts
+		scalarOK bool
+		vecOK    bool
+	}{
+		{
+			desc: "valid names",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name: "fOo123",
+					Help: "Some help.",
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "valid names & constant labels",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:   "foo",
+					Help:   "Some help.",
+					Labels: Labels{"foo": "bar"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "name with Tally-forbidden characters",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name: "foo:bar",
+					Help: "Some help.",
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "no name",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Help: "Some help.",
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
+		{
+			desc: "no help",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name: "foo",
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
+		{
+			desc: "valid names but invalid label key",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:   "foo",
+					Help:   "Some help.",
+					Labels: Labels{"foo:foo": "bar"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "valid names but invalid label value",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:   "foo",
+					Help:   "Some help.",
+					Labels: Labels{"foo": "bar:bar"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: true,
+			vecOK:    false,
+		},
+		{
+			desc: "valid names & variable labels",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "foo",
+					Help:           "Some help.",
+					VariableLabels: []string{"baz"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: false,
+			vecOK:    true,
+		},
+		{
+			desc: "valid names, constant labels, & variable labels",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "foo",
+					Help:           "Some help.",
+					Labels:         Labels{"foo": "bar"},
+					VariableLabels: []string{"baz"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: false,
+			vecOK:    true,
+		},
+		{
+			desc: "valid names & constant labels, but invalid variable labels",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "foo",
+					Help:           "Some help.",
+					Labels:         Labels{"foo": "bar"},
+					VariableLabels: []string{"baz:baz"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: false,
+			vecOK:    true,
+		},
+		{
+			desc: "valid labels, no unit",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "foo",
+					Help:           "Some help.",
+					Labels:         Labels{"foo": "bar"},
+					VariableLabels: []string{"baz"},
+				},
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
+		{
+			desc: "valid labels, negative unit",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "foo",
+					Help:           "Some help.",
+					Labels:         Labels{"foo": "bar"},
+					VariableLabels: []string{"baz"},
+				},
+				Unit:    -1 * time.Millisecond,
+				Buckets: []int64{1000, 1000 * 60},
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
+		{
+			desc: "valid labels, no buckets",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "foo",
+					Help:           "Some help.",
+					Labels:         Labels{"foo": "bar"},
+					VariableLabels: []string{"baz"},
+				},
+				Unit: time.Millisecond,
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
+		{
+			desc: "valid labels, buckets out of order",
+			opts: HistogramOpts{
+				Opts: Opts{
+					Name:           "foo",
+					Help:           "Some help.",
+					Labels:         Labels{"foo": "bar"},
+					VariableLabels: []string{"baz"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{1000 * 60, 1000},
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			if tt.scalarOK {
+				assertScalarHistogramOptsOK(t, tt.opts)
+			} else {
+				assertSimpleHistogramOptsFail(t, tt.opts)
+			}
+			if tt.vecOK {
+				assertVectorHistogramOptsOK(t, tt.opts)
+			} else {
+				assertVectorHistogramOptsFail(t, tt.opts)
+			}
+		})
+	}
+}
+
+func justRegistry(r *Registry, _ *Controller) *Registry {
+	return r
+}
+
+func assertScalarOptsOK(t testing.TB, opts Opts) {
+	_, err := justRegistry(New()).NewCounter(opts)
+	assert.NoError(t, err, "Expected success from NewCounter.")
+
+	_, err = justRegistry(New()).NewGauge(opts)
+	assert.NoError(t, err, "Expected success from NewGauge.")
+}
+
+func assertScalarOptsFail(t testing.TB, opts Opts) {
+	_, err := justRegistry(New()).NewCounter(opts)
+	assert.Error(t, err, "Expected an error from NewCounter.")
+
+	_, err = justRegistry(New()).NewGauge(opts)
+	assert.Error(t, err, "Expected an error from NewGauge.")
+}
+
+func assertVectorOptsOK(t testing.TB, opts Opts) {
+	_, err := justRegistry(New()).NewCounterVector(opts)
+	assert.NoError(t, err, "Expected success from NewCounterVector.")
+
+	_, err = justRegistry(New()).NewGaugeVector(opts)
+	assert.NoError(t, err, "Expected success from NewGaugeVector.")
+}
+
+func assertVectorOptsFail(t testing.TB, opts Opts) {
+	_, err := justRegistry(New()).NewCounterVector(opts)
+	assert.Error(t, err, "Expected an error from NewCounterVector.")
+
+	_, err = justRegistry(New()).NewGaugeVector(opts)
+	assert.Error(t, err, "Expected an error from NewGaugeVector.")
+}
+
+func assertScalarHistogramOptsOK(t testing.TB, opts HistogramOpts) {
+	_, err := justRegistry(New()).NewHistogram(opts)
+	assert.NoError(t, err, "Expected success from NewLatencies.")
+}
+
+func assertSimpleHistogramOptsFail(t testing.TB, opts HistogramOpts) {
+	_, err := justRegistry(New()).NewHistogram(opts)
+	assert.Error(t, err, "Expected an error from NewLatencies.")
+}
+
+func assertVectorHistogramOptsOK(t testing.TB, opts HistogramOpts) {
+	_, err := justRegistry(New()).NewHistogramVector(opts)
+	assert.NoError(t, err, "Expected success from NewLatenciesVector.")
+}
+
+func assertVectorHistogramOptsFail(t testing.TB, opts HistogramOpts) {
+	_, err := justRegistry(New()).NewHistogramVector(opts)
+	assert.Error(t, err, "Expected an error from NewLatenciesVector.")
+}

--- a/registry.go
+++ b/registry.go
@@ -34,6 +34,23 @@ func newRegistry(core *coreRegistry, labels Labels) *Registry {
 	}
 }
 
+// Labeled creates a new Registry with new constant labels appended to the
+// current Registry's existing labels. Label names and values are
+// automatically scrubbed, with invalid characters replaced by underscores.
+func (r *Registry) Labeled(ls Labels) *Registry {
+	if r == nil {
+		return nil
+	}
+	newLabels := make(Labels, len(r.constLabels)+len(ls))
+	for k, v := range r.constLabels {
+		newLabels[k] = v
+	}
+	for k, v := range ls {
+		newLabels[scrubName(k)] = scrubLabelValue(v)
+	}
+	return newRegistry(r.core, newLabels)
+}
+
 // NewCounter constructs a new Counter.
 func (r *Registry) NewCounter(opts Opts) (*Counter, error) {
 	if r == nil {

--- a/registry.go
+++ b/registry.go
@@ -23,11 +23,13 @@ package metrics
 // A Registry is a scoped metric registry. All metrics created with a Registry
 // will have the Registry's labels appended to them.
 type Registry struct {
+	core        *coreRegistry
 	constLabels Labels
 }
 
-func newRegistry(labels Labels) *Registry {
+func newRegistry(core *coreRegistry, labels Labels) *Registry {
 	return &Registry{
+		core:        core,
 		constLabels: labels,
 	}
 }
@@ -41,7 +43,15 @@ func (r *Registry) NewCounter(opts Opts) (*Counter, error) {
 	if err := opts.validateScalar(); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	meta, err := newMetadata(opts)
+	if err != nil {
+		return nil, err
+	}
+	c := newCounter(meta)
+	if err := r.core.register(c); err != nil {
+		return nil, err
+	}
+	return c, nil
 }
 
 // NewGauge constructs a new Gauge.
@@ -53,7 +63,15 @@ func (r *Registry) NewGauge(opts Opts) (*Gauge, error) {
 	if err := opts.validateScalar(); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	meta, err := newMetadata(opts)
+	if err != nil {
+		return nil, err
+	}
+	g := newGauge(meta)
+	if err := r.core.register(g); err != nil {
+		return nil, err
+	}
+	return g, nil
 }
 
 // NewHistogram constructs a new Histogram.
@@ -65,7 +83,15 @@ func (r *Registry) NewHistogram(opts HistogramOpts) (*Histogram, error) {
 	if err := opts.validateScalar(); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	meta, err := newMetadata(opts.Opts)
+	if err != nil {
+		return nil, err
+	}
+	h := newHistogram(meta)
+	if err := r.core.register(h); err != nil {
+		return nil, err
+	}
+	return h, nil
 }
 
 // NewCounterVector constructs a new CounterVector.
@@ -77,7 +103,15 @@ func (r *Registry) NewCounterVector(opts Opts) (*CounterVector, error) {
 	if err := opts.validateVector(); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	meta, err := newMetadata(opts)
+	if err != nil {
+		return nil, err
+	}
+	cv := newCounterVector(meta)
+	if err := r.core.register(cv); err != nil {
+		return nil, err
+	}
+	return cv, nil
 }
 
 // NewGaugeVector constructs a new GaugeVector.
@@ -89,7 +123,15 @@ func (r *Registry) NewGaugeVector(opts Opts) (*GaugeVector, error) {
 	if err := opts.validateVector(); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	meta, err := newMetadata(opts)
+	if err != nil {
+		return nil, err
+	}
+	gv := newGaugeVector(meta)
+	if err := r.core.register(gv); err != nil {
+		return nil, err
+	}
+	return gv, nil
 }
 
 // NewHistogramVector constructs a new HistogramVector.
@@ -101,7 +143,15 @@ func (r *Registry) NewHistogramVector(opts HistogramOpts) (*HistogramVector, err
 	if err := opts.validateVector(); err != nil {
 		return nil, err
 	}
-	return nil, nil
+	meta, err := newMetadata(opts.Opts)
+	if err != nil {
+		return nil, err
+	}
+	hv := newHistogramVector(meta)
+	if err := r.core.register(hv); err != nil {
+		return nil, err
+	}
+	return hv, nil
 }
 
 func (r *Registry) addConstLabels(opts Opts) Opts {

--- a/registry.go
+++ b/registry.go
@@ -104,7 +104,7 @@ func (r *Registry) NewHistogram(opts HistogramOpts) (*Histogram, error) {
 	if err != nil {
 		return nil, err
 	}
-	h := newHistogram(meta)
+	h := newHistogram(meta, opts.Unit, opts.Buckets)
 	if err := r.core.register(h); err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (r *Registry) NewHistogramVector(opts HistogramOpts) (*HistogramVector, err
 	if err != nil {
 		return nil, err
 	}
-	hv := newHistogramVector(meta)
+	hv := newHistogramVector(meta, opts.Unit, opts.Buckets)
 	if err := r.core.register(hv); err != nil {
 		return nil, err
 	}

--- a/registry.go
+++ b/registry.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+// A Registry is a scoped metric registry. All metrics created with a Registry
+// will have the Registry's labels appended to them.
+type Registry struct {
+	constLabels Labels
+}
+
+func newRegistry(labels Labels) *Registry {
+	return &Registry{
+		constLabels: labels,
+	}
+}
+
+// NewCounter constructs a new Counter.
+func (r *Registry) NewCounter(opts Opts) (*Counter, error) {
+	if r == nil {
+		return nil, nil
+	}
+	opts = r.addConstLabels(opts)
+	if err := opts.validateScalar(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// NewGauge constructs a new Gauge.
+func (r *Registry) NewGauge(opts Opts) (*Gauge, error) {
+	if r == nil {
+		return nil, nil
+	}
+	opts = r.addConstLabels(opts)
+	if err := opts.validateScalar(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// NewHistogram constructs a new Histogram.
+func (r *Registry) NewHistogram(opts HistogramOpts) (*Histogram, error) {
+	if r == nil {
+		return nil, nil
+	}
+	opts.Opts = r.addConstLabels(opts.Opts)
+	if err := opts.validateScalar(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// NewCounterVector constructs a new CounterVector.
+func (r *Registry) NewCounterVector(opts Opts) (*CounterVector, error) {
+	if r == nil {
+		return nil, nil
+	}
+	opts = r.addConstLabels(opts)
+	if err := opts.validateVector(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// NewGaugeVector constructs a new GaugeVector.
+func (r *Registry) NewGaugeVector(opts Opts) (*GaugeVector, error) {
+	if r == nil {
+		return nil, nil
+	}
+	opts = r.addConstLabels(opts)
+	if err := opts.validateVector(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+// NewHistogramVector constructs a new HistogramVector.
+func (r *Registry) NewHistogramVector(opts HistogramOpts) (*HistogramVector, error) {
+	if r == nil {
+		return nil, nil
+	}
+	opts.Opts = r.addConstLabels(opts.Opts)
+	if err := opts.validateVector(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (r *Registry) addConstLabels(opts Opts) Opts {
+	if len(r.constLabels) == 0 {
+		return opts
+	}
+	labels := make(Labels, len(r.constLabels)+len(opts.Labels))
+	for k, v := range r.constLabels {
+		labels[k] = v
+	}
+	for k, v := range opts.Labels {
+		labels[k] = v
+	}
+	opts.Labels = labels
+	return opts
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -22,6 +22,7 @@ package metrics
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,6 +46,12 @@ func TestScalarMetricDuplicates(t *testing.T) {
 	t.Run("different type", func(t *testing.T) {
 		// Even if you change the metric type, you still can't re-use metadata.
 		_, err := r.NewGauge(opts)
+		assert.Error(t, err)
+		_, err = r.NewHistogram(HistogramOpts{
+			Opts:    opts,
+			Unit:    time.Nanosecond,
+			Buckets: []int64{1, 2},
+		})
 		assert.Error(t, err)
 	})
 
@@ -158,6 +165,12 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("different type", func(t *testing.T) {
 		// Even if you change the metric type, you still can't re-use metadata.
 		_, err := r.NewGaugeVector(opts)
+		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
+		_, err = r.NewHistogramVector(HistogramOpts{
+			Opts:    opts,
+			Unit:    time.Nanosecond,
+			Buckets: []int64{1, 2},
+		})
 		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
 	})
 

--- a/registry_test.go
+++ b/registry_test.go
@@ -1,0 +1,302 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScalarMetricDuplicates(t *testing.T) {
+	r, _ := New()
+	opts := Opts{
+		Name: "foo",
+		Help: "help",
+	}
+	_, err := r.NewCounter(opts)
+	assert.NoError(t, err, "Failed first registration.")
+
+	t.Run("same type", func(t *testing.T) {
+		// You can't reuse options with the same metric type.
+		_, err := r.NewCounter(opts)
+		assert.Error(t, err)
+	})
+
+	t.Run("different type", func(t *testing.T) {
+		// Even if you change the metric type, you still can't re-use metadata.
+		_, err := r.NewGauge(opts)
+		assert.Error(t, err)
+	})
+
+	t.Run("different help", func(t *testing.T) {
+		// Changing the help string doesn't change the metric's identity.
+		_, err := r.NewCounter(Opts{
+			Name: "foo",
+			Help: "different help",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("added dimensions", func(t *testing.T) {
+		// Can't have the same metric name with added dimensions.
+		_, err := r.NewCounter(Opts{
+			Name:   "foo",
+			Help:   "help",
+			Labels: Labels{"bar": "baz"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("different dimensions", func(t *testing.T) {
+		// Even if the number of dimensions is the same, metrics with the same
+		// name must have the same dimensions.
+		_, err := r.NewCounter(Opts{
+			Name:   "dimensions",
+			Help:   "help",
+			Labels: Labels{"bar": "baz"},
+		})
+		assert.NoError(t, err, "Failed to register new metric.")
+		_, err = r.NewCounter(Opts{
+			Name:   "dimensions",
+			Help:   "help",
+			Labels: Labels{"bing": "quux"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("same dimensions", func(t *testing.T) {
+		// If a metric has the same name and dimensions, the label values may
+		// change. This allows users to (inefficiently) create what are
+		// effectively vectors - a collection of metrics with the same name and
+		// label names, but different label values.
+		_, err := r.NewCounter(Opts{
+			Name:   "dimensions",
+			Help:   "help",
+			Labels: Labels{"bar": "quux"},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("duplicate scrubbed name", func(t *testing.T) {
+		// Uniqueness is enforced after the metric name is scrubbed.
+		_, err := r.NewCounter(Opts{
+			Name: "scrubbed_name",
+			Help: "help",
+		})
+		assert.NoError(t, err, "Failed to register new metric.")
+		_, err = r.NewCounter(Opts{
+			Name: "scrubbed&name",
+			Help: "help",
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("duplicate scrubbed dimensions", func(t *testing.T) {
+		// Uniqueness is enforced after labels are scrubbed.
+		_, err := r.NewCounter(Opts{
+			Name:   "scrubbed_dimensions",
+			Help:   "help",
+			Labels: Labels{"b_r": "baz"},
+		})
+		assert.NoError(t, err, "Failed to register new metric.")
+		_, err = r.NewCounter(Opts{
+			Name:   "scrubbed_dimensions",
+			Help:   "help",
+			Labels: Labels{"b&r": "baz"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("constant label name specified twice", func(t *testing.T) {
+		// Within a single user-supplied set of labels, scrubbing may not
+		// introduce duplicates.
+		_, err = r.NewCounter(Opts{
+			Name:   "user_error_constant_labels",
+			Help:   "help",
+			Labels: Labels{"b_r": "baz", "b&r": "baz"},
+		})
+		assert.Error(t, err)
+	})
+}
+
+func TestVectorMetricDuplicates(t *testing.T) {
+	r, _ := New()
+	opts := Opts{
+		Name:           "foo",
+		Help:           "help",
+		VariableLabels: []string{"foo"},
+	}
+	_, err := r.NewCounterVector(opts)
+	assert.NoError(t, err, "Failed first registration.")
+
+	t.Run("same type", func(t *testing.T) {
+		// You can't reuse options with the same metric type.
+		_, err := r.NewCounterVector(opts)
+		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
+	})
+
+	t.Run("different type", func(t *testing.T) {
+		// Even if you change the metric type, you still can't re-use metadata.
+		_, err := r.NewGaugeVector(opts)
+		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
+	})
+
+	t.Run("different help", func(t *testing.T) {
+		// Changing the help string doesn't change the metric's identity.
+		_, err := r.NewCounterVector(Opts{
+			Name:           "foo",
+			Help:           "different help",
+			VariableLabels: []string{"foo"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("added dimensions", func(t *testing.T) {
+		// Can't have the same metric name with added dimensions.
+		_, err := r.NewCounterVector(Opts{
+			Name:           "foo",
+			Help:           "help",
+			VariableLabels: []string{"foo"},
+			Labels:         Labels{"bar": "baz"},
+		})
+		assert.Error(t, err, "Shouldn't be able to add constant labels.")
+		_, err = r.NewCounterVector(Opts{
+			Name:           "foo",
+			Help:           "help",
+			VariableLabels: []string{"foo", "bar"},
+		})
+		assert.Error(t, err, "Shouldn't be able to add variable labels.")
+	})
+
+	t.Run("different dimensions", func(t *testing.T) {
+		// Even if the number of dimensions is the same, metrics with the same
+		// name must have the same dimensions.
+		_, err := r.NewCounterVector(Opts{
+			Name:           "foo",
+			Help:           "help",
+			VariableLabels: []string{"bar"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("same dimensions", func(t *testing.T) {
+		// If a metric has the same name and dimensions, the label values
+		// may change. (Again, this would be more efficiently modeled as a
+		// higher-dimensionality vector.)
+		_, err := r.NewCounterVector(Opts{
+			Name:           "dimensions",
+			Help:           "help",
+			Labels:         Labels{"bar": "baz"},
+			VariableLabels: []string{"foo"},
+		})
+		assert.NoError(t, err)
+		_, err = r.NewCounterVector(Opts{
+			Name:           "dimensions",
+			Help:           "help",
+			Labels:         Labels{"bar": "quux"},
+			VariableLabels: []string{"foo"},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("vectors own dimensions", func(t *testing.T) {
+		// If a vector with given dimensions exists, scalars that could be part of
+		// that vector may not exist. In other words, for a given set of
+		// dimensions, users can't sometimes use a vector and sometimes use a la
+		// carte scalars.
+
+		// dims: foo, baz
+		_, err := r.NewCounterVector(Opts{
+			Name:           "ownership",
+			Help:           "help",
+			Labels:         Labels{"foo": "bar"},
+			VariableLabels: []string{"baz"},
+		})
+		require.NoError(t, err)
+
+		// same dims
+		_, err = r.NewCounter(Opts{
+			Name:   "ownership",
+			Help:   "help",
+			Labels: Labels{"foo": "bar", "baz": "quux"},
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("duplicate scrubbed name", func(t *testing.T) {
+		// Uniqueness is enforced after the metric name is scrubbed.
+		_, err := r.NewCounterVector(Opts{
+			Name:           "scrubbed_name",
+			Help:           "help",
+			VariableLabels: []string{"bar"},
+		})
+		assert.NoError(t, err, "Failed to register new metric.")
+		_, err = r.NewCounterVector(Opts{
+			Name:           "scrubbed&name",
+			Help:           "help",
+			VariableLabels: []string{"bar"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("duplicate scrubbed dimensions", func(t *testing.T) {
+		// Uniqueness is enforced after labels are scrubbed.
+		_, err := r.NewCounterVector(Opts{
+			Name:           "scrubbed_dimensions",
+			Help:           "help",
+			Labels:         Labels{"b_r": "baz"},
+			VariableLabels: []string{"q__x"},
+		})
+		assert.NoError(t, err, "Failed to register new metric.")
+		_, err = r.NewCounterVector(Opts{
+			Name:           "scrubbed_dimensions",
+			Help:           "help",
+			Labels:         Labels{"b&r": "baz"},
+			VariableLabels: []string{"q&&x"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("constant label name specified twice", func(t *testing.T) {
+		// Within a single user-supplied set of constant labels, scrubbing may not
+		// introduce duplicates.
+		_, err = r.NewCounterVector(Opts{
+			Name:           "user_error_constant_labels",
+			Help:           "help",
+			Labels:         Labels{"b_r": "baz", "b&r": "baz"},
+			VariableLabels: []string{"quux"},
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("variable label name specified twice", func(t *testing.T) {
+		// Within a single user-supplied set of variable labels, scrubbing may not
+		// introduce duplicates.
+		_, err = r.NewCounterVector(Opts{
+			Name:           "user_error_variable_labels",
+			Help:           "help",
+			VariableLabels: []string{"f__", "f&&"},
+		})
+		assert.Error(t, err)
+	})
+}

--- a/registry_test.go
+++ b/registry_test.go
@@ -312,6 +312,16 @@ func TestVectorMetricDuplicates(t *testing.T) {
 		})
 		assert.Error(t, err)
 	})
+
+	t.Run("constant and variable label name overlap", func(t *testing.T) {
+		_, err = r.NewCounterVector(Opts{
+			Name:           "user_error_label_overlaps",
+			Help:           "help",
+			Labels:         Labels{"foo": "one"},
+			VariableLabels: []string{"foo"},
+		})
+		assert.Error(t, err)
+	})
 }
 
 func TestLabeledPrecedence(t *testing.T) {

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"sort"
+	"time"
+)
+
+// A SimpleSnapshot is a point-in-time snapshot of the state of any
+// non-histogram metric.
+type SimpleSnapshot struct {
+	Name   string
+	Labels Labels
+	Value  int64
+}
+
+func (s SimpleSnapshot) less(other SimpleSnapshot) bool {
+	if s.Name != other.Name {
+		return s.Name < other.Name
+	}
+	return s.Labels.less(other.Labels)
+}
+
+// A HistogramSnapshot is a point-in-time snapshot of the state of a
+// Histogram.
+type HistogramSnapshot struct {
+	Name   string
+	Labels Labels
+	Unit   time.Duration
+	Values []int64 // rounded up to bucket upper bounds
+}
+
+func (l HistogramSnapshot) less(other HistogramSnapshot) bool {
+	if l.Name != other.Name {
+		return l.Name < other.Name
+	}
+	return l.Labels.less(other.Labels)
+}
+
+// A Snapshot exposes all the metrics contained in a Registry. It's useful in
+// tests, but shouldn't be used in production code.
+type Snapshot struct {
+	Counters   []SimpleSnapshot
+	Gauges     []SimpleSnapshot
+	Histograms []HistogramSnapshot
+}
+
+func (s *Snapshot) sort() {
+	sort.Slice(s.Counters, func(i, j int) bool {
+		return s.Counters[i].less(s.Counters[j])
+	})
+	sort.Slice(s.Gauges, func(i, j int) bool {
+		return s.Gauges[i].less(s.Gauges[j])
+	})
+	sort.Slice(s.Histograms, func(i, j int) bool {
+		return s.Histograms[i].less(s.Histograms[j])
+	})
+}
+
+func (s *Snapshot) add(m metric) {
+	switch v := m.(type) {
+	case *Counter:
+		s.Counters = append(s.Counters, v.snapshot())
+	case *Gauge:
+		s.Gauges = append(s.Gauges, v.snapshot())
+	case *Histogram:
+		s.Histograms = append(s.Histograms, v.snapshot())
+	case *CounterVector:
+		s.Counters = append(s.Counters, v.snapshot()...)
+	case *GaugeVector:
+		s.Gauges = append(s.Gauges, v.snapshot()...)
+	case *HistogramVector:
+		s.Histograms = append(s.Histograms, v.snapshot()...)
+	}
+}

--- a/value.go
+++ b/value.go
@@ -70,7 +70,7 @@ type vector struct {
 	metrics   map[string]metric // key is variable label vals
 }
 
-func (vec *vector) getOrCreate(labels ...string) (metric, error) {
+func (vec *vector) getOrCreate(labels []string) (metric, error) {
 	if err := vec.meta.ValidateVariableLabels(labels); err != nil {
 		return nil, err
 	}

--- a/value.go
+++ b/value.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"sync"
+
+	promproto "github.com/prometheus/client_model/go"
+	"go.uber.org/atomic"
+)
+
+// Value is an atomic with some associated metadata. It's a building block
+// for higher-level metric types.
+type value struct {
+	atomic.Int64
+
+	meta       metadata
+	labelPairs []*promproto.LabelPair
+}
+
+func newValue(m metadata) value {
+	return value{
+		meta:       m,
+		labelPairs: m.MergeLabels(nil /* variable labels */),
+	}
+}
+
+func newDynamicValue(m metadata, variableLabels []string) value {
+	return value{
+		meta:       m,
+		labelPairs: m.MergeLabels(variableLabels),
+	}
+}
+
+func (v value) snapshot() SimpleSnapshot {
+	return SimpleSnapshot{
+		Name:   *v.meta.Name,
+		Labels: zip(v.labelPairs),
+		Value:  v.Load(),
+	}
+}
+
+// A vector is a collection of values that share the same metadata.
+type vector struct {
+	meta metadata
+
+	// The factory function creates a new metric given the vector's metadata
+	// and the variable label keys and values.
+	factory func(metadata, []string) metric
+
+	metricsMu sync.RWMutex
+	metrics   map[string]metric // key is variable label vals
+}
+
+func (vec *vector) getOrCreate(labels ...string) (metric, error) {
+	if err := vec.meta.ValidateVariableLabels(labels); err != nil {
+		return nil, err
+	}
+	digester := newDigester()
+	for i := 0; i < len(labels)/2; i++ {
+		digester.add("", scrubLabelValue(labels[i*2+1]))
+	}
+
+	vec.metricsMu.RLock()
+	m, ok := vec.metrics[string(digester.digest())]
+	vec.metricsMu.RUnlock()
+	if ok {
+		digester.free()
+		return m, nil
+	}
+
+	vec.metricsMu.Lock()
+	m, err := vec.newValue(digester.digest(), labels)
+	vec.metricsMu.Unlock()
+	digester.free()
+
+	return m, err
+}
+
+func (vec *vector) newValue(key []byte, variableLabels []string) (metric, error) {
+	m, ok := vec.metrics[string(key)]
+	if ok {
+		return m, nil
+	}
+	m = vec.factory(vec.meta, variableLabels)
+	vec.metrics[string(key)] = m
+	return m, nil
+}
+
+func (vec *vector) snapshot() []SimpleSnapshot {
+	vec.metricsMu.RLock()
+	defer vec.metricsMu.RUnlock()
+	snaps := make([]SimpleSnapshot, 0, len(vec.metrics))
+	for _, m := range vec.metrics {
+		switch v := m.(type) {
+		case *Counter:
+			snaps = append(snaps, v.snapshot())
+		case *Gauge:
+			snaps = append(snaps, v.snapshot())
+		}
+	}
+	return snaps
+}


### PR DESCRIPTION
This series of commits adds implementations of counters, gauges, histograms, and their vectorized variants. It also adds the ability to snapshot metrics for unit tests. Coming in a subsequent PR:

- Push to Tally.
- Prometheus-compatible scraping.
- A more full-featured testing package (building upon the snapshotting functionality included here).

This PR should *definitely* be reviewed commit-by-commit: I've tried to make the commit messages a useful guide to reviewers.