### PR TITLE
Add functional options for registries and controllers

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -104,7 +104,7 @@ func (c *Counter) push(target push.Target) {
 		return
 	}
 	if c.pusher == nil {
-		c.pusher = target.NewCounter(push.Opts{
+		c.pusher = target.NewCounter(push.Spec{
 			Name:   *c.val.meta.Name,
 			Labels: zip(c.val.labelPairs),
 		})

--- a/counter_test.go
+++ b/counter_test.go
@@ -32,16 +32,16 @@ func TestCounter(t *testing.T) {
 	r = r.Labeled(Labels{"service": "users"})
 
 	t.Run("duplicate constant label names", func(t *testing.T) {
-		_, err := r.NewCounter(Opts{
+		_, err := r.NewCounter(Spec{
 			Name:   "test_counter",
 			Help:   "help",
 			Labels: Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate label names
 		})
-		assert.Error(t, err, "Expected an error constructing a counter with invalid options.")
+		assert.Error(t, err, "Expected an error constructing a counter with invalid spec.")
 	})
 
-	t.Run("valid opts", func(t *testing.T) {
-		counter, err := r.NewCounter(Opts{
+	t.Run("valid spec", func(t *testing.T) {
+		counter, err := r.NewCounter(Spec{
 			Name:   "test_counter",
 			Help:   "Some help.",
 			Labels: Labels{"foo": "bar"},
@@ -66,12 +66,12 @@ func TestCounter(t *testing.T) {
 func TestCounterVector(t *testing.T) {
 	newVector := func() (*CounterVector, *Controller) {
 		r, c := New()
-		opts := Opts{
+		spec := Spec{
 			Name:           "test_counter",
 			Help:           "Some help.",
 			VariableLabels: []string{"var"},
 		}
-		vec, err := r.NewCounterVector(opts)
+		vec, err := r.NewCounterVector(spec)
 		require.NoError(t, err, "Unexpected error constructing vector.")
 		return vec, c
 	}
@@ -124,21 +124,21 @@ func TestCounterVectorConstructionErrors(t *testing.T) {
 	r, _ := New()
 
 	t.Run("duplicate constant label names", func(t *testing.T) {
-		_, err := r.NewCounterVector(Opts{
+		_, err := r.NewCounterVector(Spec{
 			Name:           "test_counter",
 			Help:           "help",
 			Labels:         Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate label names
 			VariableLabels: []string{"var"},
 		})
-		assert.Error(t, err, "Expected an error constructing a counter vector with invalid options.")
+		assert.Error(t, err, "Expected an error constructing a counter vector with invalid spec.")
 	})
 
 	t.Run("duplicate variable label names", func(t *testing.T) {
-		_, err := r.NewCounterVector(Opts{
+		_, err := r.NewCounterVector(Spec{
 			Name:           "test_counter",
 			Help:           "help",
 			VariableLabels: []string{"var", "var"},
 		})
-		assert.Error(t, err, "Expected an error constructing a counter vector with invalid options.")
+		assert.Error(t, err, "Expected an error constructing a counter vector with invalid spec.")
 	})
 }

--- a/gauge.go
+++ b/gauge.go
@@ -136,7 +136,7 @@ func (g *Gauge) push(target push.Target) {
 		return
 	}
 	if g.pusher == nil {
-		g.pusher = target.NewGauge(push.Opts{
+		g.pusher = target.NewGauge(push.Spec{
 			Name:   *g.val.meta.Name,
 			Labels: zip(g.val.labelPairs),
 		})

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -32,16 +32,16 @@ func TestGauge(t *testing.T) {
 	r = r.Labeled(Labels{"service": "users"})
 
 	t.Run("duplicate constant labels", func(t *testing.T) {
-		_, err := r.NewGauge(Opts{
+		_, err := r.NewGauge(Spec{
 			Name:   "test_gauge",
 			Help:   "help",
 			Labels: Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate label names
 		})
-		assert.Error(t, err, "Expected an error constructing a gauge with invalid options.")
+		assert.Error(t, err, "Expected an error constructing a gauge with invalid spec.")
 	})
 
-	t.Run("valid opts", func(t *testing.T) {
-		gauge, err := r.NewGauge(Opts{
+	t.Run("valid spec", func(t *testing.T) {
+		gauge, err := r.NewGauge(Spec{
 			Name:   "test_gauge",
 			Help:   "Some help.",
 			Labels: Labels{"foo": "bar"},
@@ -69,12 +69,12 @@ func TestGauge(t *testing.T) {
 func TestGaugeVector(t *testing.T) {
 	newVector := func() (*GaugeVector, *Controller) {
 		r, c := New()
-		opts := Opts{
+		spec := Spec{
 			Name:           "test_gauge",
 			Help:           "Some help.",
 			VariableLabels: []string{"var"},
 		}
-		vec, err := r.NewGaugeVector(opts)
+		vec, err := r.NewGaugeVector(spec)
 		require.NoError(t, err, "Unexpected error constructing vector.")
 		return vec, c
 	}
@@ -125,21 +125,21 @@ func TestGaugeVectorConstructionErrors(t *testing.T) {
 	r, _ := New()
 
 	t.Run("duplicate constant label names", func(t *testing.T) {
-		_, err := r.NewGaugeVector(Opts{
+		_, err := r.NewGaugeVector(Spec{
 			Name:           "test_gauge",
 			Help:           "help",
 			Labels:         Labels{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate label names
 			VariableLabels: []string{"var"},
 		})
-		assert.Error(t, err, "Expected an error constructing a gauge vector with invalid options.")
+		assert.Error(t, err, "Expected an error constructing a gauge vector with invalid spec.")
 	})
 
 	t.Run("duplicate variable label names", func(t *testing.T) {
-		_, err := r.NewGaugeVector(Opts{
+		_, err := r.NewGaugeVector(Spec{
 			Name:           "test_gauge",
 			Help:           "help",
 			VariableLabels: []string{"var", "var"},
 		})
-		assert.Error(t, err, "Expected an error constructing a gauge vector with invalid options.")
+		assert.Error(t, err, "Expected an error constructing a gauge vector with invalid spec.")
 	})
 }

--- a/histogram.go
+++ b/histogram.go
@@ -178,8 +178,8 @@ func (h *Histogram) push(target push.Target) {
 		return
 	}
 	if h.pusher == nil {
-		h.pusher = target.NewHistogram(push.HistogramOpts{
-			Opts: push.Opts{
+		h.pusher = target.NewHistogram(push.HistogramSpec{
+			Spec: push.Spec{
 				Name:   *h.meta.Name,
 				Labels: zip(h.labelPairs),
 			},

--- a/integration_test.go
+++ b/integration_test.go
@@ -41,7 +41,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Controller {
 	root, controller := New()
 	reg := root.Labeled(Labels{"service": "users"})
 
-	counter, err := reg.NewCounter(Opts{
+	counter, err := reg.NewCounter(Spec{
 		Name:        "test_counter",
 		Help:        "counter help",
 		Labels:      Labels{"foo": "counter"},
@@ -50,7 +50,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Controller {
 	require.NoError(t, err, "Failed to create counter.")
 	counter.Inc()
 
-	counterVec, err := reg.NewCounterVector(Opts{
+	counterVec, err := reg.NewCounterVector(Spec{
 		Name:           "test_counter_vector",
 		Help:           "counter vector help",
 		Labels:         Labels{"foo": "counter_vector"},
@@ -67,7 +67,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Controller {
 		"baz", "bazval2",
 	).Inc()
 
-	gauge, err := reg.NewGauge(Opts{
+	gauge, err := reg.NewGauge(Spec{
 		Name:        "test_gauge",
 		Help:        "gauge help",
 		Labels:      Labels{"foo": "gauge"},
@@ -76,7 +76,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Controller {
 	require.NoError(t, err, "Failed to create gauge.")
 	gauge.Store(42)
 
-	gaugeVec, err := reg.NewGaugeVector(Opts{
+	gaugeVec, err := reg.NewGaugeVector(Spec{
 		Name:           "test_gauge_vector",
 		Help:           "gauge vector help",
 		Labels:         Labels{"foo": "gauge_vector"},
@@ -93,8 +93,8 @@ func initializeMetrics(t testing.TB, disablePush bool) *Controller {
 		"baz", "bazval2",
 	).Store(20)
 
-	hist, err := reg.NewHistogram(HistogramOpts{
-		Opts: Opts{
+	hist, err := reg.NewHistogram(HistogramSpec{
+		Spec: Spec{
 			Name:        "test_histogram",
 			Help:        "histogram help",
 			Labels:      Labels{"foo": "histogram"},
@@ -106,8 +106,8 @@ func initializeMetrics(t testing.TB, disablePush bool) *Controller {
 	require.NoError(t, err, "Failed to create histogram.")
 	hist.Observe(time.Millisecond)
 
-	histVec, err := reg.NewHistogramVector(HistogramOpts{
-		Opts: Opts{
+	histVec, err := reg.NewHistogramVector(HistogramSpec{
+		Spec: Spec{
 			Name:           "test_histogram_vector",
 			Help:           "histogram vector help",
 			Labels:         Labels{"foo": "histogram_vector"},

--- a/metadata.go
+++ b/metadata.go
@@ -31,8 +31,8 @@ import (
 // Match the Prometheus error text.
 var errInconsistentCardinality = errors.New("inconsistent label cardinality")
 
-// metadata stores our internal representation of metric options. Adding this
-// layer of indirection between the user-facing options and the metric
+// metadata stores our internal representation of metric specs. Adding this
+// layer of indirection between the user-facing specs and the metric
 // constructors serves two purposes: it centralizes the logic for calculating
 // a variety of derived values, and it lets the remainder of the package
 // assume that all user-supplied data has already been fully validated.
@@ -45,7 +45,7 @@ type metadata struct {
 	variableLabelNames []string // unscrubbed
 }
 
-func newMetadata(o Opts) (metadata, error) {
+func newMetadata(o Spec) (metadata, error) {
 	// TODO: Consider checking for duplicate labels with Bloom filters,
 	// allocating maps only if we suspect a duplicate.
 	sortedConstNames := make([]string, 0, len(o.Labels))
@@ -126,7 +126,7 @@ func (m metadata) MergeLabels(variableLabels []string) []*promproto.LabelPair {
 }
 
 // ValidateVariableLabels checks that the user-supplied variable label names
-// and values match the options supplied at vector creation.
+// and values match the spec supplied at vector creation.
 func (m metadata) ValidateVariableLabels(variableLabels []string) error {
 	if len(variableLabels) != 2*len(m.variableLabelNames) {
 		return errInconsistentCardinality

--- a/metrics.go
+++ b/metrics.go
@@ -25,8 +25,14 @@ import (
 	"go.uber.org/net/metrics/push"
 )
 
+// An Option configures registries and controllers. Currently, there are no
+// exported Options.
+type Option interface {
+	unimplemented()
+}
+
 // New constructs a Registry and Controller.
-func New() (*Registry, *Controller) {
+func New(opts ...Option) (*Registry, *Controller) {
 	core := newCoreRegistry()
 	return newRegistry(core, Labels{}), newController(core)
 }

--- a/nop_test.go
+++ b/nop_test.go
@@ -55,27 +55,27 @@ func TestNopHistogramVector(t *testing.T) {
 func TestNopRegistry(t *testing.T) {
 	var r *Registry
 	r = r.Labeled(Labels{"foo": "bar"})
-	c, err := r.NewCounter(Opts{})
+	c, err := r.NewCounter(Spec{})
 	assert.NoError(t, err, "Error calling NewCounter on nil Registry.")
 	assertNopCounter(t, c)
 
-	cv, err := r.NewCounterVector(Opts{})
+	cv, err := r.NewCounterVector(Spec{})
 	assert.NoError(t, err, "Error calling NewCounterVector on nil Registry.")
 	assertNopCounterVector(t, cv)
 
-	g, err := r.NewGauge(Opts{})
+	g, err := r.NewGauge(Spec{})
 	assert.NoError(t, err, "Error calling NewGauge on nil Registry.")
 	assertNopGauge(t, g)
 
-	gv, err := r.NewGaugeVector(Opts{})
+	gv, err := r.NewGaugeVector(Spec{})
 	assert.NoError(t, err, "Error calling NewGaugeVector on nil Registry.")
 	assertNopGaugeVector(t, gv)
 
-	h, err := r.NewHistogram(HistogramOpts{})
+	h, err := r.NewHistogram(HistogramSpec{})
 	assert.NoError(t, err, "Error calling NewHistogram on nil Registry.")
 	assertNopHistogram(t, h)
 
-	hv, err := r.NewHistogramVector(HistogramOpts{})
+	hv, err := r.NewHistogramVector(HistogramSpec{})
 	assertNopHistogramVector(t, hv)
 }
 

--- a/push/nop.go
+++ b/push/nop.go
@@ -25,9 +25,9 @@ type nop struct{}
 // NewNop returns a no-op Target.
 func NewNop() Target { return &nop{} }
 
-func (n *nop) NewCounter(Opts) Counter              { return n }
-func (n *nop) NewGauge(Opts) Gauge                  { return n }
-func (n *nop) NewHistogram(HistogramOpts) Histogram { return &nopHistogram{} }
+func (n *nop) NewCounter(Spec) Counter              { return n }
+func (n *nop) NewGauge(Spec) Gauge                  { return n }
+func (n *nop) NewHistogram(HistogramSpec) Histogram { return &nopHistogram{} }
 func (n *nop) Set(int64)                            {}
 
 type nopHistogram struct{}

--- a/push/nop_test.go
+++ b/push/nop_test.go
@@ -24,7 +24,7 @@ import "testing"
 
 func TestNop(t *testing.T) {
 	target := NewNop()
-	target.NewCounter(Opts{}).Set(1)
-	target.NewGauge(Opts{}).Set(1)
-	target.NewHistogram(HistogramOpts{}).Set(1, 1)
+	target.NewCounter(Spec{}).Set(1)
+	target.NewGauge(Spec{}).Set(1)
+	target.NewHistogram(HistogramSpec{}).Set(1, 1)
 }

--- a/push/push.go
+++ b/push/push.go
@@ -28,20 +28,20 @@ package push // import "go.uber.org/net/metrics/push"
 // A concrete implementation of this interface that works with StatsD and M3
 // is available in the go.uber.org/net/metrics/tallypush package.
 type Target interface {
-	NewCounter(Opts) Counter
-	NewGauge(Opts) Gauge
-	NewHistogram(HistogramOpts) Histogram
+	NewCounter(Spec) Counter
+	NewGauge(Spec) Gauge
+	NewHistogram(HistogramSpec) Histogram
 }
 
-// Opts configure counters and gauges.
-type Opts struct {
+// A Spec configures counters and gauges.
+type Spec struct {
 	Name   string
 	Labels map[string]string
 }
 
-// HistogramOpts configure histograms.
-type HistogramOpts struct {
-	Opts
+// A HistogramSpec configures histograms.
+type HistogramSpec struct {
+	Spec
 
 	Buckets []int64 // upper bounds, inclusive
 }

--- a/registry.go
+++ b/registry.go
@@ -52,15 +52,15 @@ func (r *Registry) Labeled(ls Labels) *Registry {
 }
 
 // NewCounter constructs a new Counter.
-func (r *Registry) NewCounter(opts Opts) (*Counter, error) {
+func (r *Registry) NewCounter(spec Spec) (*Counter, error) {
 	if r == nil {
 		return nil, nil
 	}
-	opts = r.addConstLabels(opts)
-	if err := opts.validateScalar(); err != nil {
+	spec = r.addConstLabels(spec)
+	if err := spec.validateScalar(); err != nil {
 		return nil, err
 	}
-	meta, err := newMetadata(opts)
+	meta, err := newMetadata(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -72,15 +72,15 @@ func (r *Registry) NewCounter(opts Opts) (*Counter, error) {
 }
 
 // NewGauge constructs a new Gauge.
-func (r *Registry) NewGauge(opts Opts) (*Gauge, error) {
+func (r *Registry) NewGauge(spec Spec) (*Gauge, error) {
 	if r == nil {
 		return nil, nil
 	}
-	opts = r.addConstLabels(opts)
-	if err := opts.validateScalar(); err != nil {
+	spec = r.addConstLabels(spec)
+	if err := spec.validateScalar(); err != nil {
 		return nil, err
 	}
-	meta, err := newMetadata(opts)
+	meta, err := newMetadata(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -92,19 +92,19 @@ func (r *Registry) NewGauge(opts Opts) (*Gauge, error) {
 }
 
 // NewHistogram constructs a new Histogram.
-func (r *Registry) NewHistogram(opts HistogramOpts) (*Histogram, error) {
+func (r *Registry) NewHistogram(spec HistogramSpec) (*Histogram, error) {
 	if r == nil {
 		return nil, nil
 	}
-	opts.Opts = r.addConstLabels(opts.Opts)
-	if err := opts.validateScalar(); err != nil {
+	spec.Spec = r.addConstLabels(spec.Spec)
+	if err := spec.validateScalar(); err != nil {
 		return nil, err
 	}
-	meta, err := newMetadata(opts.Opts)
+	meta, err := newMetadata(spec.Spec)
 	if err != nil {
 		return nil, err
 	}
-	h := newHistogram(meta, opts.Unit, opts.Buckets)
+	h := newHistogram(meta, spec.Unit, spec.Buckets)
 	if err := r.core.register(h); err != nil {
 		return nil, err
 	}
@@ -112,15 +112,15 @@ func (r *Registry) NewHistogram(opts HistogramOpts) (*Histogram, error) {
 }
 
 // NewCounterVector constructs a new CounterVector.
-func (r *Registry) NewCounterVector(opts Opts) (*CounterVector, error) {
+func (r *Registry) NewCounterVector(spec Spec) (*CounterVector, error) {
 	if r == nil {
 		return nil, nil
 	}
-	opts = r.addConstLabels(opts)
-	if err := opts.validateVector(); err != nil {
+	spec = r.addConstLabels(spec)
+	if err := spec.validateVector(); err != nil {
 		return nil, err
 	}
-	meta, err := newMetadata(opts)
+	meta, err := newMetadata(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -132,15 +132,15 @@ func (r *Registry) NewCounterVector(opts Opts) (*CounterVector, error) {
 }
 
 // NewGaugeVector constructs a new GaugeVector.
-func (r *Registry) NewGaugeVector(opts Opts) (*GaugeVector, error) {
+func (r *Registry) NewGaugeVector(spec Spec) (*GaugeVector, error) {
 	if r == nil {
 		return nil, nil
 	}
-	opts = r.addConstLabels(opts)
-	if err := opts.validateVector(); err != nil {
+	spec = r.addConstLabels(spec)
+	if err := spec.validateVector(); err != nil {
 		return nil, err
 	}
-	meta, err := newMetadata(opts)
+	meta, err := newMetadata(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -152,36 +152,36 @@ func (r *Registry) NewGaugeVector(opts Opts) (*GaugeVector, error) {
 }
 
 // NewHistogramVector constructs a new HistogramVector.
-func (r *Registry) NewHistogramVector(opts HistogramOpts) (*HistogramVector, error) {
+func (r *Registry) NewHistogramVector(spec HistogramSpec) (*HistogramVector, error) {
 	if r == nil {
 		return nil, nil
 	}
-	opts.Opts = r.addConstLabels(opts.Opts)
-	if err := opts.validateVector(); err != nil {
+	spec.Spec = r.addConstLabels(spec.Spec)
+	if err := spec.validateVector(); err != nil {
 		return nil, err
 	}
-	meta, err := newMetadata(opts.Opts)
+	meta, err := newMetadata(spec.Spec)
 	if err != nil {
 		return nil, err
 	}
-	hv := newHistogramVector(meta, opts.Unit, opts.Buckets)
+	hv := newHistogramVector(meta, spec.Unit, spec.Buckets)
 	if err := r.core.register(hv); err != nil {
 		return nil, err
 	}
 	return hv, nil
 }
 
-func (r *Registry) addConstLabels(opts Opts) Opts {
+func (r *Registry) addConstLabels(spec Spec) Spec {
 	if len(r.constLabels) == 0 {
-		return opts
+		return spec
 	}
-	labels := make(Labels, len(r.constLabels)+len(opts.Labels))
+	labels := make(Labels, len(r.constLabels)+len(spec.Labels))
 	for k, v := range r.constLabels {
 		labels[k] = v
 	}
-	for k, v := range opts.Labels {
+	for k, v := range spec.Labels {
 		labels[k] = v
 	}
-	opts.Labels = labels
-	return opts
+	spec.Labels = labels
+	return spec
 }

--- a/spec.go
+++ b/spec.go
@@ -27,8 +27,8 @@ import (
 	"time"
 )
 
-// Opts configure Counters, Gauges, CounterVectors, and GaugeVectors.
-type Opts struct {
+// A Spec configures Counters, Gauges, CounterVectors, and GaugeVectors.
+type Spec struct {
 	Name           string
 	Help           string
 	Labels         Labels
@@ -36,39 +36,39 @@ type Opts struct {
 	DisablePush    bool
 }
 
-func (o Opts) validate() error {
-	if len(o.Name) == 0 {
+func (s Spec) validate() error {
+	if len(s.Name) == 0 {
 		return errors.New("all metrics must have a name")
 	}
-	if o.Help == "" {
+	if s.Help == "" {
 		return errors.New("metric help must not be empty")
 	}
 	return nil
 }
 
-func (o Opts) validateScalar() error {
-	if err := o.validate(); err != nil {
+func (s Spec) validateScalar() error {
+	if err := s.validate(); err != nil {
 		return err
 	}
-	if len(o.VariableLabels) > 0 {
+	if len(s.VariableLabels) > 0 {
 		return errors.New("only vectors may have variable labels")
 	}
 	return nil
 }
 
-func (o Opts) validateVector() error {
-	if err := o.validate(); err != nil {
+func (s Spec) validateVector() error {
+	if err := s.validate(); err != nil {
 		return err
 	}
-	if len(o.VariableLabels) == 0 {
+	if len(s.VariableLabels) == 0 {
 		return errors.New("vectors must have variable labels")
 	}
 	return nil
 }
 
-// HistogramOpts configure Histograms and HistogramVectors.
-type HistogramOpts struct {
-	Opts
+// A HistogramSpec configures Histograms and HistogramVectors.
+type HistogramSpec struct {
+	Spec
 
 	// Durations are exported to Prometheus as simple numbers, not strings or
 	// rich objects. Unit specifies the desired granularity for latency
@@ -82,29 +82,29 @@ type HistogramOpts struct {
 	Buckets []int64
 }
 
-func (ho HistogramOpts) validateScalar() error {
-	if err := ho.validateLatencies(); err != nil {
+func (hs HistogramSpec) validateScalar() error {
+	if err := hs.validateLatencies(); err != nil {
 		return err
 	}
-	return ho.Opts.validateScalar()
+	return hs.Spec.validateScalar()
 }
 
-func (ho HistogramOpts) validateVector() error {
-	if err := ho.validateLatencies(); err != nil {
+func (hs HistogramSpec) validateVector() error {
+	if err := hs.validateLatencies(); err != nil {
 		return err
 	}
-	return ho.Opts.validateVector()
+	return hs.Spec.validateVector()
 }
 
-func (ho HistogramOpts) validateLatencies() error {
-	if ho.Unit < 1 {
-		return fmt.Errorf("duration unit must be positive, got %v", ho.Unit)
+func (hs HistogramSpec) validateLatencies() error {
+	if hs.Unit < 1 {
+		return fmt.Errorf("duration unit must be positive, got %v", hs.Unit)
 	}
-	if len(ho.Buckets) == 0 {
+	if len(hs.Buckets) == 0 {
 		return fmt.Errorf("must specify some buckets")
 	}
 	prev := int64(math.MinInt64)
-	for _, upper := range ho.Buckets {
+	for _, upper := range hs.Buckets {
 		if upper <= prev {
 			return fmt.Errorf("bucket upper bounds must be sorted in increasing order")
 		}

--- a/spec_test.go
+++ b/spec_test.go
@@ -27,16 +27,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOptsValidation(t *testing.T) {
+func TestSpecValidation(t *testing.T) {
 	tests := []struct {
 		desc     string
-		opts     Opts
+		spec     Spec
 		scalarOK bool
 		vecOK    bool
 	}{
 		{
 			desc: "valid names",
-			opts: Opts{
+			spec: Spec{
 				Name: "fOo123",
 				Help: "Some help.",
 			},
@@ -45,7 +45,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names & constant labels",
-			opts: Opts{
+			spec: Spec{
 				Name:   "foo",
 				Help:   "Some help.",
 				Labels: Labels{"foo": "bar"},
@@ -55,7 +55,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "name with Tally-forbidden characters",
-			opts: Opts{
+			spec: Spec{
 				Name: "foo:bar",
 				Help: "Some help.",
 			},
@@ -64,7 +64,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "no name",
-			opts: Opts{
+			spec: Spec{
 				Help: "Some help.",
 			},
 			scalarOK: false,
@@ -72,7 +72,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "no help",
-			opts: Opts{
+			spec: Spec{
 				Name: "foo",
 			},
 			scalarOK: false,
@@ -80,7 +80,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names but invalid label key",
-			opts: Opts{
+			spec: Spec{
 				Name:   "foo",
 				Help:   "Some help.",
 				Labels: Labels{"foo:foo": "bar"},
@@ -90,7 +90,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names but invalid label value",
-			opts: Opts{
+			spec: Spec{
 				Name:   "foo",
 				Help:   "Some help.",
 				Labels: Labels{"foo": "bar:bar"},
@@ -100,7 +100,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names & variable labels",
-			opts: Opts{
+			spec: Spec{
 				Name:           "foo",
 				Help:           "Some help.",
 				VariableLabels: []string{"baz"},
@@ -110,7 +110,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names, constant labels, & variable labels",
-			opts: Opts{
+			spec: Spec{
 				Name:           "foo",
 				Help:           "Some help.",
 				Labels:         Labels{"foo": "bar"},
@@ -121,7 +121,7 @@ func TestOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names & constant labels, but invalid variable labels",
-			opts: Opts{
+			spec: Spec{
 				Name:           "foo",
 				Help:           "Some help.",
 				Labels:         Labels{"foo": "bar"},
@@ -135,30 +135,30 @@ func TestOptsValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			if tt.scalarOK {
-				assertScalarOptsOK(t, tt.opts)
+				assertScalarSpecOK(t, tt.spec)
 			} else {
-				assertScalarOptsFail(t, tt.opts)
+				assertScalarSpecFail(t, tt.spec)
 			}
 			if tt.vecOK {
-				assertVectorOptsOK(t, tt.opts)
+				assertVectorSpecOK(t, tt.spec)
 			} else {
-				assertVectorOptsFail(t, tt.opts)
+				assertVectorSpecFail(t, tt.spec)
 			}
 		})
 	}
 }
 
-func TestHistogramOptsValidation(t *testing.T) {
+func TestHistogramSpecValidation(t *testing.T) {
 	tests := []struct {
 		desc     string
-		opts     HistogramOpts
+		spec     HistogramSpec
 		scalarOK bool
 		vecOK    bool
 	}{
 		{
 			desc: "valid names",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name: "fOo123",
 					Help: "Some help.",
 				},
@@ -170,8 +170,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names & constant labels",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:   "foo",
 					Help:   "Some help.",
 					Labels: Labels{"foo": "bar"},
@@ -184,8 +184,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "name with Tally-forbidden characters",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name: "foo:bar",
 					Help: "Some help.",
 				},
@@ -197,8 +197,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "no name",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Help: "Some help.",
 				},
 				Unit:    time.Millisecond,
@@ -209,8 +209,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "no help",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name: "foo",
 				},
 				Unit:    time.Millisecond,
@@ -221,8 +221,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names but invalid label key",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:   "foo",
 					Help:   "Some help.",
 					Labels: Labels{"foo:foo": "bar"},
@@ -235,8 +235,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names but invalid label value",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:   "foo",
 					Help:   "Some help.",
 					Labels: Labels{"foo": "bar:bar"},
@@ -249,8 +249,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names & variable labels",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:           "foo",
 					Help:           "Some help.",
 					VariableLabels: []string{"baz"},
@@ -263,8 +263,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names, constant labels, & variable labels",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:           "foo",
 					Help:           "Some help.",
 					Labels:         Labels{"foo": "bar"},
@@ -278,8 +278,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid names & constant labels, but invalid variable labels",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:           "foo",
 					Help:           "Some help.",
 					Labels:         Labels{"foo": "bar"},
@@ -293,8 +293,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid labels, no unit",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:           "foo",
 					Help:           "Some help.",
 					Labels:         Labels{"foo": "bar"},
@@ -307,8 +307,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid labels, negative unit",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:           "foo",
 					Help:           "Some help.",
 					Labels:         Labels{"foo": "bar"},
@@ -322,8 +322,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid labels, no buckets",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:           "foo",
 					Help:           "Some help.",
 					Labels:         Labels{"foo": "bar"},
@@ -336,8 +336,8 @@ func TestHistogramOptsValidation(t *testing.T) {
 		},
 		{
 			desc: "valid labels, buckets out of order",
-			opts: HistogramOpts{
-				Opts: Opts{
+			spec: HistogramSpec{
+				Spec: Spec{
 					Name:           "foo",
 					Help:           "Some help.",
 					Labels:         Labels{"foo": "bar"},
@@ -354,14 +354,14 @@ func TestHistogramOptsValidation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			if tt.scalarOK {
-				assertScalarHistogramOptsOK(t, tt.opts)
+				assertScalarHistogramSpecOK(t, tt.spec)
 			} else {
-				assertSimpleHistogramOptsFail(t, tt.opts)
+				assertSimpleHistogramSpecFail(t, tt.spec)
 			}
 			if tt.vecOK {
-				assertVectorHistogramOptsOK(t, tt.opts)
+				assertVectorHistogramSpecOK(t, tt.spec)
 			} else {
-				assertVectorHistogramOptsFail(t, tt.opts)
+				assertVectorHistogramSpecFail(t, tt.spec)
 			}
 		})
 	}
@@ -371,54 +371,54 @@ func justRegistry(r *Registry, _ *Controller) *Registry {
 	return r
 }
 
-func assertScalarOptsOK(t testing.TB, opts Opts) {
-	_, err := justRegistry(New()).NewCounter(opts)
+func assertScalarSpecOK(t testing.TB, spec Spec) {
+	_, err := justRegistry(New()).NewCounter(spec)
 	assert.NoError(t, err, "Expected success from NewCounter.")
 
-	_, err = justRegistry(New()).NewGauge(opts)
+	_, err = justRegistry(New()).NewGauge(spec)
 	assert.NoError(t, err, "Expected success from NewGauge.")
 }
 
-func assertScalarOptsFail(t testing.TB, opts Opts) {
-	_, err := justRegistry(New()).NewCounter(opts)
+func assertScalarSpecFail(t testing.TB, spec Spec) {
+	_, err := justRegistry(New()).NewCounter(spec)
 	assert.Error(t, err, "Expected an error from NewCounter.")
 
-	_, err = justRegistry(New()).NewGauge(opts)
+	_, err = justRegistry(New()).NewGauge(spec)
 	assert.Error(t, err, "Expected an error from NewGauge.")
 }
 
-func assertVectorOptsOK(t testing.TB, opts Opts) {
-	_, err := justRegistry(New()).NewCounterVector(opts)
+func assertVectorSpecOK(t testing.TB, spec Spec) {
+	_, err := justRegistry(New()).NewCounterVector(spec)
 	assert.NoError(t, err, "Expected success from NewCounterVector.")
 
-	_, err = justRegistry(New()).NewGaugeVector(opts)
+	_, err = justRegistry(New()).NewGaugeVector(spec)
 	assert.NoError(t, err, "Expected success from NewGaugeVector.")
 }
 
-func assertVectorOptsFail(t testing.TB, opts Opts) {
-	_, err := justRegistry(New()).NewCounterVector(opts)
+func assertVectorSpecFail(t testing.TB, spec Spec) {
+	_, err := justRegistry(New()).NewCounterVector(spec)
 	assert.Error(t, err, "Expected an error from NewCounterVector.")
 
-	_, err = justRegistry(New()).NewGaugeVector(opts)
+	_, err = justRegistry(New()).NewGaugeVector(spec)
 	assert.Error(t, err, "Expected an error from NewGaugeVector.")
 }
 
-func assertScalarHistogramOptsOK(t testing.TB, opts HistogramOpts) {
-	_, err := justRegistry(New()).NewHistogram(opts)
+func assertScalarHistogramSpecOK(t testing.TB, spec HistogramSpec) {
+	_, err := justRegistry(New()).NewHistogram(spec)
 	assert.NoError(t, err, "Expected success from NewLatencies.")
 }
 
-func assertSimpleHistogramOptsFail(t testing.TB, opts HistogramOpts) {
-	_, err := justRegistry(New()).NewHistogram(opts)
+func assertSimpleHistogramSpecFail(t testing.TB, spec HistogramSpec) {
+	_, err := justRegistry(New()).NewHistogram(spec)
 	assert.Error(t, err, "Expected an error from NewLatencies.")
 }
 
-func assertVectorHistogramOptsOK(t testing.TB, opts HistogramOpts) {
-	_, err := justRegistry(New()).NewHistogramVector(opts)
+func assertVectorHistogramSpecOK(t testing.TB, spec HistogramSpec) {
+	_, err := justRegistry(New()).NewHistogramVector(spec)
 	assert.NoError(t, err, "Expected success from NewLatenciesVector.")
 }
 
-func assertVectorHistogramOptsFail(t testing.TB, opts HistogramOpts) {
-	_, err := justRegistry(New()).NewHistogramVector(opts)
+func assertVectorHistogramSpecFail(t testing.TB, spec HistogramSpec) {
+	_, err := justRegistry(New()).NewHistogramVector(spec)
 	assert.Error(t, err, "Expected an error from NewLatenciesVector.")
 }

--- a/tallypush/tally.go
+++ b/tallypush/tally.go
@@ -38,31 +38,31 @@ type target struct {
 	tally.Scope
 }
 
-func (tp *target) NewCounter(opts push.Opts) push.Counter {
+func (tp *target) NewCounter(spec push.Spec) push.Counter {
 	return &counter{
-		Counter: tp.Tagged(opts.Labels).Counter(opts.Name),
+		Counter: tp.Tagged(spec.Labels).Counter(spec.Name),
 	}
 }
 
-func (tp *target) NewGauge(opts push.Opts) push.Gauge {
-	return &gauge{tp.Tagged(opts.Labels).Gauge(opts.Name)}
+func (tp *target) NewGauge(spec push.Spec) push.Gauge {
+	return &gauge{tp.Tagged(spec.Labels).Gauge(spec.Name)}
 }
 
-func (tp *target) NewHistogram(opts push.HistogramOpts) push.Histogram {
-	buckets := make([]float64, len(opts.Buckets))
-	for i := range opts.Buckets {
-		if opts.Buckets[i] == math.MaxInt64 {
+func (tp *target) NewHistogram(spec push.HistogramSpec) push.Histogram {
+	buckets := make([]float64, len(spec.Buckets))
+	for i := range spec.Buckets {
+		if spec.Buckets[i] == math.MaxInt64 {
 			buckets[i] = math.MaxFloat64
 		} else {
-			buckets[i] = float64(opts.Buckets[i])
+			buckets[i] = float64(spec.Buckets[i])
 		}
 	}
 	return &latency{
-		Histogram: tp.Tagged(opts.Labels).Histogram(
-			opts.Name,
+		Histogram: tp.Tagged(spec.Labels).Histogram(
+			spec.Name,
 			tally.ValueBuckets(buckets),
 		),
-		lasts: make(map[int64]int64, len(opts.Buckets)),
+		lasts: make(map[int64]int64, len(spec.Buckets)),
 	}
 }
 

--- a/tallypush/tally_test.go
+++ b/tallypush/tally_test.go
@@ -39,7 +39,7 @@ func newScope() tally.TestScope {
 func TestCounter(t *testing.T) {
 	scope := newScope()
 	target := New(scope)
-	c := target.NewCounter(push.Opts{
+	c := target.NewCounter(push.Spec{
 		Name:   "test_counter",
 		Labels: metrics.Labels{"foo": "bar"},
 	})
@@ -53,7 +53,7 @@ func TestCounter(t *testing.T) {
 func TestGauge(t *testing.T) {
 	scope := newScope()
 	target := New(scope)
-	g := target.NewGauge(push.Opts{
+	g := target.NewGauge(push.Spec{
 		Name:   "test_gauge",
 		Labels: metrics.Labels{"foo": "bar"},
 	})
@@ -67,8 +67,8 @@ func TestGauge(t *testing.T) {
 func TestHistogram(t *testing.T) {
 	scope := newScope()
 	target := New(scope)
-	h := target.NewHistogram(push.HistogramOpts{
-		Opts:    push.Opts{Name: "test_histogram", Labels: metrics.Labels{"foo": "bar"}},
+	h := target.NewHistogram(push.HistogramSpec{
+		Spec:    push.Spec{Name: "test_histogram", Labels: metrics.Labels{"foo": "bar"}},
 		Buckets: []int64{5, 10, math.MaxInt64},
 	})
 	h.Set(5, 1)


### PR DESCRIPTION
For forward compatibility, we want the top-level `New` constructor to take a variadic number of functional options. Unfortunately, we've used the word "options" for individual metric configuration (`Opts` and `HistogramOpts`). This PR replaces our current use of `Opts` with `Spec`, then adds a top-level `Option` type.

The first two commits are purely renaming; the last one adds functional options.