### PR TITLE
Rename to align more closely with Tally

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,8 @@ coverage:
                                #   option: "X%" a static target percentage to hit
         if_not_found: success  # if parent is not found report status as success, error, or failure
         if_ci_failed: error    # if ci fails report status as success, error, or failure
+
+    patch:
+      default:
+        enabled: yes
+        target: 70

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ go:
   - 1.8
   - 1.9
 go_import_path: go.uber.org/net/metrics
-env:
-  global:
-    - TEST_TIME_SCALE=10
 cache:
   directories:
     - vendor

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifdef SHOULD_LINT
 	@echo "Installing test dependencies for vet..."
 	@go test -i $(PKGS)
 	@echo "Checking vet..."
-	@go tool vet $(VET_RULES) $(LINT_FILES) 2>&1 | tee -a lint.log
+	@go vet $(VET_RULES) $(LINT_PKGS) 2>&1 | tee -a lint.log
 	@echo "Checking lint..."
 	@golint $(LINT_PKGS) 2>&1 | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs..."

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package bucket provides utility functions for constructing and merging
+// histogram buckets. Buckets are meant to be used in the base metrics
+// package's HistogramSpec struct.
+package bucket // import "go.uber.org/net/metrics/bucket"
+
+import (
+	"errors"
+)
+
+// NewRPCLatency returns a hand-crafted set of buckets useful for tracking the
+// latency of RPCs (in milliseconds). Buckets range from 1 to 10000 (i.e.,
+// 1ms-10s), getting less granular as latency increases.
+func NewRPCLatency() []int64 {
+	return []int64{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+		12, 14, 16, 18, 20,
+		25, 30, 35, 40, 45, 50,
+		60, 70, 80, 90, 100,
+		120, 140, 160, 180, 200,
+		250, 300, 350, 400, 450, 500,
+		600, 700, 800, 900, 1000,
+		1500, 2000, 2500, 3000,
+		4000, 5000, 7500, 10000,
+	}
+}
+
+// NewExponential creates n exponential buckets, starting with the supplied
+// initial value and increasing by a user-defined factor each time.
+//
+// If n is less than one, the initial value is less than one, or the factor
+// is less than two, NewExponential returns a nil slice.
+func NewExponential(initial, factor int64, n int) []int64 {
+	if n < 1 || initial < 1 || factor < 2 {
+		return nil
+	}
+	buckets := make([]int64, n)
+	buckets[0] = initial
+	for i := 1; i < len(buckets); i++ {
+		buckets[i] = buckets[i-1] * factor
+	}
+	return buckets
+}
+
+// NewLinear creates n linear buckets, starting with the supplied
+// initial value and increasing by a user-defined width.
+//
+// If n or width are less than one, NewLinear returns a nil slice.
+func NewLinear(initial, width int64, n int) []int64 {
+	if n < 1 || width < 1 {
+		return nil
+	}
+	buckets := make([]int64, n)
+	buckets[0] = initial
+	for i := 1; i < len(buckets); i++ {
+		buckets[i] = buckets[i-1] + width
+	}
+	return buckets
+}
+
+// Flatten concatenates multiple sets of buckets into a single slice. After
+// flattening, it checks that the result is sorted and that no buckets are
+// duplicated.
+func Flatten(buckets ...[]int64) ([]int64, error) {
+	merged := flatten(buckets)
+	if asc := isAscending(merged); !asc {
+		return nil, errors.New("after flattening, buckets are not strictly ascending")
+	}
+	return merged, nil
+}
+
+func isAscending(ints []int64) bool {
+	// Don't use sort.IsSorted, since it permits duplicate elements.
+	if len(ints) < 2 {
+		return true
+	}
+	prev := ints[0]
+	for j := 1; j < len(ints); j++ {
+		if prev >= ints[j] {
+			return false
+		}
+		prev = ints[j]
+	}
+	return true
+}
+
+func flatten(iss [][]int64) []int64 {
+	var n int
+	for _, is := range iss {
+		n += len(is)
+	}
+	flat := make([]int64, 0, n)
+	for _, is := range iss {
+		flat = append(flat, is...)
+	}
+	return flat
+}

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bucket
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type int64s []int64
+
+func (is int64s) Len() int           { return len(is) }
+func (is int64s) Less(i, j int) bool { return is[i] < is[j] }
+func (is int64s) Swap(i, j int)      { is[i], is[j] = is[j], is[i] }
+
+func assertStrictlySorted(t testing.TB, is []int64) {
+	// We want the same result as the production code's isAscending without
+	// copying logic.
+	if !sort.IsSorted(int64s(is)) {
+		t.Logf("not sorted: %v", is)
+		t.Fail()
+	}
+	if hasDuplicates(is) {
+		t.Logf("has duplicate buckets: %v", is)
+		t.Fail()
+	}
+}
+
+func hasDuplicates(is []int64) bool {
+	set := make(map[int64]struct{}, len(is))
+	for _, i := range is {
+		if _, ok := set[i]; ok {
+			return true
+		}
+		set[i] = struct{}{}
+	}
+	return false
+}
+
+func TestNewRPC(t *testing.T) {
+	bs := NewRPCLatency()
+	require.True(t, len(bs) > 0, "Expected at least one bucket.")
+	assertStrictlySorted(t, bs)
+}
+
+func TestNewExponential(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs := NewExponential(1, 2, 3)
+		assert.Equal(t, []int64{1, 2, 4}, bs)
+	})
+	t.Run("too few buckets", func(t *testing.T) {
+		bs := NewExponential(1, 2, 0)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative start", func(t *testing.T) {
+		bs := NewExponential(-1, 2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero start", func(t *testing.T) {
+		bs := NewExponential(0, 2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative factor", func(t *testing.T) {
+		bs := NewExponential(1, -2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero factor", func(t *testing.T) {
+		bs := NewExponential(1, 0, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+}
+
+func TestNewLinear(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs := NewLinear(-2, 2, 4)
+		assert.Equal(t, []int64{-2, 0, 2, 4}, bs)
+	})
+	t.Run("too few buckets", func(t *testing.T) {
+		bs := NewLinear(2, 2, 0)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative width", func(t *testing.T) {
+		bs := NewLinear(-2, -1, 4)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero width", func(t *testing.T) {
+		bs := NewLinear(-2, 0, 4)
+		assert.Equal(t, 0, len(bs))
+	})
+}
+
+func TestFlatten(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs, err := Flatten([]int64{1, 2, 3}, []int64{5, 10, 15})
+		require.NoError(t, err, "Failed to flatten buckets.")
+		assert.Equal(t, []int64{1, 2, 3, 5, 10, 15}, bs)
+	})
+	t.Run("subslice not sorted", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 3, 2}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("subslice not uniqued", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 2}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("slices overlap", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 7}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("slices share bounds", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 5}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+}

--- a/controller.go
+++ b/controller.go
@@ -58,7 +58,7 @@ func (c *Controller) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // Snapshot returns a point-in-time view of all the metrics contained in the
 // controller's registry. It's safe to use concurrently, but is relatively
 // expensive and designed for use in unit tests.
-func (c *Controller) Snapshot() *Snapshot {
+func (c *Controller) Snapshot() *RegistrySnapshot {
 	return c.snapshot()
 }
 

--- a/core.go
+++ b/core.go
@@ -34,10 +34,10 @@ const _defaultCollectionSize = 128
 // A core is a collection of metrics. Uniqueness is enforced with two checks,
 // just like the vanilla Prometheus client:
 //
-// First, any two metrics with the same name must have the same label names
+// First, any two metrics with the same name must have the same tag names
 // (both constant and variable).
 //
-// Second, no two metrics can share the same name and the same constant label
+// Second, no two metrics can share the same name and the same constant tag
 // names and values.
 //
 // The test suite for metric uniqueness is well-commented and explores the
@@ -79,13 +79,13 @@ func (c *core) register(m metric) error {
 	c.Lock()
 	if existing, ok := c.dimsByName[*meta.Name]; ok && existing != meta.Dims {
 		c.Unlock()
-		return fmt.Errorf("a metric with name %q and different label "+
+		return fmt.Errorf("a metric with name %q and different tag "+
 			"names is already registered", *meta.Name)
 	}
 	if _, ok := c.ids[string(id.digest())]; ok {
 		c.Unlock()
 		return fmt.Errorf("a metric with name %q and the same constant "+
-			"label names and values is already registered", *meta.Name)
+			"tag names and values is already registered", *meta.Name)
 	}
 	c.dimsByName[*meta.Name] = meta.Dims
 	c.ids[string(id.digest())] = struct{}{}

--- a/core.go
+++ b/core.go
@@ -31,8 +31,8 @@ import (
 
 const _defaultCollectionSize = 128
 
-// A coreRegistry is a collection of metrics. Uniqueness is enforced with two
-// checks, just like the vanilla Prometheus client:
+// A core is a collection of metrics. Uniqueness is enforced with two checks,
+// just like the vanilla Prometheus client:
 //
 // First, any two metrics with the same name must have the same label names
 // (both constant and variable).
@@ -42,7 +42,7 @@ const _defaultCollectionSize = 128
 //
 // The test suite for metric uniqueness is well-commented and explores the
 // consequences of these two rules.
-type coreRegistry struct {
+type core struct {
 	sync.RWMutex
 
 	dimsByName map[string]string
@@ -51,8 +51,8 @@ type coreRegistry struct {
 	gatherer   prometheus.Gatherer
 }
 
-func newCoreRegistry() *coreRegistry {
-	c := &coreRegistry{
+func newCore() *core {
+	c := &core{
 		dimsByName: make(map[string]string, _defaultCollectionSize),
 		ids:        make(map[string]struct{}, _defaultCollectionSize),
 		metrics:    make([]metric, 0, _defaultCollectionSize),
@@ -69,7 +69,7 @@ func newCoreRegistry() *coreRegistry {
 	return c
 }
 
-func (c *coreRegistry) register(m metric) error {
+func (c *core) register(m metric) error {
 	id := newDigester()
 	defer id.free()
 
@@ -95,10 +95,10 @@ func (c *coreRegistry) register(m metric) error {
 	return nil
 }
 
-func (c *coreRegistry) snapshot() *RegistrySnapshot {
+func (c *core) snapshot() *RootSnapshot {
 	c.RLock()
 	defer c.RUnlock()
-	s := &RegistrySnapshot{}
+	s := &RootSnapshot{}
 	for _, m := range c.metrics {
 		s.add(m)
 	}
@@ -106,7 +106,7 @@ func (c *coreRegistry) snapshot() *RegistrySnapshot {
 	return s
 }
 
-func (c *coreRegistry) push(target push.Target) {
+func (c *core) push(target push.Target) {
 	c.RLock()
 	for _, m := range c.metrics {
 		m.push(target)

--- a/core.go
+++ b/core.go
@@ -32,13 +32,8 @@ import (
 const _defaultCollectionSize = 128
 
 // A core is a collection of metrics. Uniqueness is enforced with two checks,
-// just like the vanilla Prometheus client:
-//
-// First, any two metrics with the same name must have the same tag names
-// (both constant and variable).
-//
-// Second, no two metrics can share the same name and the same constant tag
-// names and values.
+// explained in the documentation of the Root struct. The checks are slightly
+// stricter than those used by the official Prometheus client.
 //
 // The test suite for metric uniqueness is well-commented and explores the
 // consequences of these two rules.

--- a/core.go
+++ b/core.go
@@ -95,10 +95,10 @@ func (c *coreRegistry) register(m metric) error {
 	return nil
 }
 
-func (c *coreRegistry) snapshot() *Snapshot {
+func (c *coreRegistry) snapshot() *RegistrySnapshot {
 	c.RLock()
 	defer c.RUnlock()
-	s := &Snapshot{}
+	s := &RegistrySnapshot{}
 	for _, m := range c.metrics {
 		s.add(m)
 	}

--- a/counter.go
+++ b/counter.go
@@ -29,9 +29,8 @@ import (
 )
 
 // A Counter is a monotonically increasing value, like a car's odometer. All
-// its exported methods are safe to use concurrently.
-//
-// Nil *Counters are safe no-op implementations.
+// its exported methods are safe to use concurrently, and nil *Counters are
+// safe no-op implementations.
 type Counter struct {
 	val    value
 	pusher push.Counter
@@ -114,9 +113,8 @@ func (c *Counter) push(target push.Target) {
 
 // A CounterVector is a collection of Counters that share a name and some
 // constant tags, but also have a consistent set of variable tags. All
-// exported methods are safe to use concurrently.
-//
-// A nil *CounterVector is safe to use, and always returns no-op counters.
+// exported methods are safe to use concurrently. Nil *CounterVectors are safe
+// to use and always return no-op counters.
 //
 // For a general description of vector types, see the package-level
 // documentation.

--- a/counter.go
+++ b/counter.go
@@ -78,7 +78,7 @@ func (c *Counter) describe() metadata {
 	return c.val.meta
 }
 
-func (c *Counter) snapshot() SimpleSnapshot {
+func (c *Counter) snapshot() Snapshot {
 	return c.val.snapshot()
 }
 

--- a/counter_test.go
+++ b/counter_test.go
@@ -32,7 +32,7 @@ func TestCounter(t *testing.T) {
 	s := root.Scope().Tagged(Tags{"service": "users"})
 
 	t.Run("duplicate constant tag names", func(t *testing.T) {
-		_, err := s.NewCounter(Spec{
+		_, err := s.Counter(Spec{
 			Name:      "test_counter",
 			Help:      "help",
 			ConstTags: Tags{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate tag names
@@ -41,7 +41,7 @@ func TestCounter(t *testing.T) {
 	})
 
 	t.Run("valid spec", func(t *testing.T) {
-		counter, err := s.NewCounter(Spec{
+		counter, err := s.Counter(Spec{
 			Name:      "test_counter",
 			Help:      "Some help.",
 			ConstTags: Tags{"foo": "bar"},
@@ -71,7 +71,7 @@ func TestCounterVector(t *testing.T) {
 			Help:    "Some help.",
 			VarTags: []string{"var"},
 		}
-		vec, err := root.Scope().NewCounterVector(spec)
+		vec, err := root.Scope().CounterVector(spec)
 		require.NoError(t, err, "Unexpected error constructing vector.")
 		return vec, root
 	}
@@ -124,7 +124,7 @@ func TestCounterVectorConstructionErrors(t *testing.T) {
 	s := New().Scope()
 
 	t.Run("duplicate constant tag names", func(t *testing.T) {
-		_, err := s.NewCounterVector(Spec{
+		_, err := s.CounterVector(Spec{
 			Name:      "test_counter",
 			Help:      "help",
 			ConstTags: Tags{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate tag names
@@ -134,7 +134,7 @@ func TestCounterVectorConstructionErrors(t *testing.T) {
 	})
 
 	t.Run("duplicate variable tag names", func(t *testing.T) {
-		_, err := s.NewCounterVector(Spec{
+		_, err := s.CounterVector(Spec{
 			Name:    "test_counter",
 			Help:    "help",
 			VarTags: []string{"var", "var"},

--- a/counter_test.go
+++ b/counter_test.go
@@ -55,7 +55,7 @@ func TestCounter(t *testing.T) {
 
 		snap := c.Snapshot()
 		require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
-		assert.Equal(t, SimpleSnapshot{
+		assert.Equal(t, Snapshot{
 			Name:   "test_counter",
 			Labels: Labels{"foo": "bar", "service": "users"},
 			Value:  3,
@@ -80,7 +80,7 @@ func TestCounterVector(t *testing.T) {
 		snap := c.Snapshot()
 		require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
 		got := snap.Counters[0]
-		assert.Equal(t, SimpleSnapshot{
+		assert.Equal(t, Snapshot{
 			Name:   "test_counter",
 			Labels: Labels{"var": expectedLabel},
 			Value:  expectedCount,

--- a/doc.go
+++ b/doc.go
@@ -18,4 +18,62 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// Package metrics is a telemetry client designed for Uber's software
+// networking team. It prioritizes performance on the hot path and integration
+// with both push- and pull-based collection systems. Like Prometheus and
+// Tally, it supports metrics tagged with arbitrary key-value pairs.
+//
+// Metric Names and Uniqueness
+//
+// Like Prometheus, but unlike Tally, metric names must be relatively long and
+// descriptive - generally speaking, metrics from the same process shouldn't
+// share names. (See the documentation for the Root struct below for a longer
+// explanation of the uniqueness rules.) For example, prefer
+// "grpc_successes_by_procedure" over "successes", since "successes" is common
+// and vague. Where relevant, metric names should indicate their unit of
+// measurement (e.g., "grpc_success_latency_ms").
+//
+// Counters and Gauges
+//
+// Counters represent monotonically increasing values, like a car's odometer.
+// Gauges represent point-in-time readings, like a car's speedometer. Both
+// counters and gauges expose not only write operations (set, add, increment,
+// etc.), but also atomic reads. This makes them easy to integrate directly
+// into your business logic: you can use them anywhere you'd otherwise use a
+// 64-bit atomic integer.
+//
+// Histograms
+//
+// This package doesn't support analogs of Tally's timer or Prometheus's
+// summary, because they can't be accurately aggregated at query time.
+// Instead, it approximates distributions of values with histograms. These
+// require more up-front work to set up, but are typically more accurate and
+// flexible when queried. See https://prometheus.io/docs/practices/histograms/
+// for a more detailed discussion of the trade-offs involved.
+//
+// Vectors
+//
+// Plain counters, gauges, and histograms have a fixed set of tags. However,
+// it's common to encounter situations where a subset of a metric's tags vary
+// constantly. For example, you might want to track the latency of your
+// database queries by table: you know the database cluster, application name,
+// and hostname at process startup, but you need to specify the table name
+// with each query. To model these situations, this package uses vectors.
+//
+// Each vector is a local cache of metrics, so accessing them is quite fast.
+// Within a vector, all metrics share a common set of constant tags and a list
+// of variable tags. In our database query example, the constant tags are
+// cluster, application, and hostname, and the only variable tag is table
+// name. Usage examples are included in the documentation for each vector
+// type.
+//
+// Push and Pull
+//
+// This package integrates with StatsD- and M3-based collection systems by
+// periodically pushing differential updates. (Users can integrate with other
+// push-based systems by implementing the push.Target interface.) It
+// integrates with pull-based collectors by exposing an HTTP handler that
+// supports Prometheus's text and protocol buffer exposition formats. Examples
+// of both push and pull integration are included in the documentation for the
+// root struct's Push and ServeHTTP methods.
 package metrics // import "go.uber.org/net/metrics"

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"time"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/net/metrics"
+	"go.uber.org/net/metrics/tallypush"
+)
+
+func Example() {
+	root := metrics.New()
+	scope := root.Scope().Tagged(metrics.Tags{
+		"host":   "db01",
+		"region": "us-west",
+	})
+
+	total, err := scope.Counter(metrics.Spec{
+		Name: "selects_completed",
+		Help: "Total number of completed SELECT queries.",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	progress, err := scope.GaugeVector(metrics.Spec{
+		Name:    "selects_in_progress",
+		Help:    "Number of in-progress SELECT queries.",
+		VarTags: []string{"table"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	trips := progress.MustGet("table" /* tag name */, "trips" /* tag value */)
+	drivers := progress.MustGet("table", "drivers")
+
+	fmt.Println("Trips:", trips.Inc())
+	total.Inc()
+	fmt.Println("Drivers:", drivers.Add(2))
+	total.Add(2)
+	fmt.Println("Drivers:", drivers.Dec())
+	fmt.Println("Trips:", trips.Dec())
+	fmt.Println("Total:", total.Load())
+
+	// Output:
+	// Trips: 1
+	// Drivers: 2
+	// Drivers: 1
+	// Trips: 0
+	// Total: 3
+}
+
+func ExampleCounter() {
+	c, err := metrics.New().Scope().Counter(metrics.Spec{
+		Name:      "selects_completed",                         // required
+		Help:      "Total number of completed SELECT queries.", // required
+		ConstTags: metrics.Tags{"host": "db01"},                // optional
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Add(2)
+}
+
+func ExampleCounterVector() {
+	vec, err := metrics.New().Scope().CounterVector(metrics.Spec{
+		Name:      "selects_completed_by_table",                   // required
+		Help:      "Number of completed SELECT queries by table.", // required
+		ConstTags: metrics.Tags{"host": "db01"},                   // optional
+		VarTags:   []string{"table"},                              // required
+	})
+	if err != nil {
+		panic(err)
+	}
+	vec.MustGet("table" /* tag name */, "trips" /* tag value */).Inc()
+}
+
+func ExampleGauge() {
+	g, err := metrics.New().Scope().Gauge(metrics.Spec{
+		Name:      "selects_in_progress",                       // required
+		Help:      "Total number of in-flight SELECT queries.", // required
+		ConstTags: metrics.Tags{"host": "db01"},                // optional
+	})
+	if err != nil {
+		panic(err)
+	}
+	g.Store(11)
+}
+
+func ExampleGaugeVector() {
+	vec, err := metrics.New().Scope().GaugeVector(metrics.Spec{
+		Name:      "selects_in_progress_by_table",                 // required
+		Help:      "Number of in-flight SELECT queries by table.", // required
+		ConstTags: metrics.Tags{"host": "db01"},                   // optional
+		VarTags:   []string{"table"},                              // optional
+	})
+	if err != nil {
+		panic(err)
+	}
+	vec.MustGet("table" /* tag name */, "trips" /* tag value */).Store(11)
+}
+
+func ExampleHistogram() {
+	h, err := metrics.New().Scope().Histogram(metrics.HistogramSpec{
+		Spec: metrics.Spec{
+			Name:      "selects_latency_ms",         // required, should indicate unit
+			Help:      "SELECT query latency.",      // required
+			ConstTags: metrics.Tags{"host": "db01"}, // optional
+		},
+		Unit:    time.Millisecond,                      // required
+		Buckets: []int64{5, 10, 25, 50, 100, 200, 500}, // required
+	})
+	if err != nil {
+		panic(err)
+	}
+	h.Observe(37 * time.Millisecond)
+}
+
+func ExampleHistogramVector() {
+	vec, err := metrics.New().Scope().HistogramVector(metrics.HistogramSpec{
+		Spec: metrics.Spec{
+			Name:      "selects_latency_by_table_ms",    // required, should indicate unit
+			Help:      "SELECT query latency by table.", // required
+			ConstTags: metrics.Tags{"host": "db01"},     // optional
+			VarTags:   []string{"table"},
+		},
+		Unit:    time.Millisecond,                      // required
+		Buckets: []int64{5, 10, 25, 50, 100, 200, 500}, // required
+	})
+	if err != nil {
+		panic(err)
+	}
+	vec.MustGet("table" /* tag name */, "trips" /* tag value */).Observe(37 * time.Millisecond)
+}
+
+func ExampleRoot_ServeHTTP() {
+	// First, construct a root and add some metrics.
+	root := metrics.New()
+	c, err := root.Scope().Counter(metrics.Spec{
+		Name:      "example",
+		Help:      "Counter demonstrating HTTP exposition.",
+		ConstTags: metrics.Tags{"host": "example01"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Inc()
+
+	// Expose the root on your HTTP server of choice.
+	mux := http.NewServeMux()
+	mux.Handle("/debug/net/metrics", root)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Your metrics are now exposed via a Prometheus-compatible handler. This
+	// example shows text output, but clients can also request the protocol
+	// buffer binary format.
+	res, err := http.Get(fmt.Sprintf("%v/debug/net/metrics", srv.URL))
+	if err != nil {
+		panic(err)
+	}
+	text, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(text))
+
+	// Output:
+	// # HELP example Counter demonstrating HTTP exposition.
+	// # TYPE example counter
+	// example{host="example01"} 1
+}
+
+func ExampleRoot_Push() {
+	// First, we need something to push to. In this example, we'll use Tally's
+	// testing scope.
+	ts := tally.NewTestScope("" /* prefix */, nil /* tags */)
+	root := metrics.New()
+
+	// Push updates to our test scope twice per second.
+	stop, err := root.Push(tallypush.New(ts), 500*time.Millisecond)
+	if err != nil {
+		panic(err)
+	}
+	defer stop()
+
+	c, err := root.Scope().Counter(metrics.Spec{
+		Name: "example",
+		Help: "Counter demonstrating push integration.",
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Inc()
+
+	// Sleep to make sure that we run at least one push, then print the counter
+	// value as seen by Tally.
+	time.Sleep(2 * time.Second)
+	fmt.Println(ts.Snapshot().Counters()["example+"].Value())
+
+	// Output:
+	// 1
+}
+
+func ExampleRoot_Snapshot() {
+	// Snapshots are the simplest way to unit test your metrics. A future
+	// release will add a more full-featured metricstest package.
+	root := metrics.New()
+	c, err := root.Scope().Counter(metrics.Spec{
+		Name:      "example",
+		Help:      "Counter demonstrating snapshots.",
+		ConstTags: metrics.Tags{"foo": "bar"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Inc()
+
+	// It's safe to snapshot your metrics in production, but keep in mind that
+	// taking a snapshot is relatively slow and expensive.
+	actual := root.Snapshot().Counters[0]
+	expected := metrics.Snapshot{
+		Name:  "example",
+		Value: 1,
+		Tags:  metrics.Tags{"foo": "bar"},
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		panic(fmt.Sprintf("expected %v, got %v", expected, actual))
+	}
+}

--- a/gauge.go
+++ b/gauge.go
@@ -29,9 +29,8 @@ import (
 )
 
 // A Gauge is a point-in-time measurement, like a car's speedometer. All its
-// exported methods are safe to use concurrently.
-//
-// Nil *Gauges are safe no-op implementations.
+// exported methods are safe to use concurrently, and nil *Gauges are safe
+// no-op implementations.
 type Gauge struct {
 	val    value
 	pusher push.Gauge
@@ -81,9 +80,10 @@ func (g *Gauge) Swap(n int64) int64 {
 	return g.val.Swap(n)
 }
 
-// CAS is a compare-and-swap. It compares the current value to the old value
-// supplied, and if they match it stores the new value. The return value
-// indicates whether the swap succeeded.
+// CAS is an atomic compare-and-swap. It compares the current value to the old
+// value supplied, and if they match it stores the new value. The return value
+// indicates whether the swap succeeded. To avoid endless CAS loops, no-op
+// gauges always return true.
 func (g *Gauge) CAS(old, new int64) bool {
 	if g == nil {
 		return true
@@ -91,7 +91,7 @@ func (g *Gauge) CAS(old, new int64) bool {
 	return g.val.CAS(old, new)
 }
 
-// Store changes the gauge's value.
+// Store sets the gauge's value.
 func (g *Gauge) Store(n int64) {
 	if g != nil {
 		g.val.Store(n)
@@ -146,9 +146,8 @@ func (g *Gauge) push(target push.Target) {
 
 // A GaugeVector is a collection of Gauges that share a name and some constant
 // tags, but also have a consistent set of variable tags. All exported methods
-// are safe to use concurrently.
-//
-// A nil *GaugeVector is safe to use, and always returns no-op gauges.
+// are safe to use concurrently. Nil *GaugeVectors are safe to use and always
+// return no-op gauges.
 //
 // For a general description of vector types, see the package-level
 // documentation.

--- a/gauge.go
+++ b/gauge.go
@@ -110,7 +110,7 @@ func (g *Gauge) describe() metadata {
 	return g.val.meta
 }
 
-func (g *Gauge) snapshot() SimpleSnapshot {
+func (g *Gauge) snapshot() Snapshot {
 	return g.val.snapshot()
 }
 

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -58,7 +58,7 @@ func TestGauge(t *testing.T) {
 		assert.True(t, gauge.CAS(42, 43), "Unexpected return value from CAS.")
 		snap := c.Snapshot()
 		require.Equal(t, 1, len(snap.Gauges), "Unexpected number of gauges.")
-		assert.Equal(t, SimpleSnapshot{
+		assert.Equal(t, Snapshot{
 			Name:   "test_gauge",
 			Labels: Labels{"foo": "bar", "service": "users"},
 			Value:  43,

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -32,7 +32,7 @@ func TestGauge(t *testing.T) {
 	s := root.Scope().Tagged(Tags{"service": "users"})
 
 	t.Run("duplicate constant tags", func(t *testing.T) {
-		_, err := s.NewGauge(Spec{
+		_, err := s.Gauge(Spec{
 			Name:      "test_gauge",
 			Help:      "help",
 			ConstTags: Tags{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate tag names
@@ -41,7 +41,7 @@ func TestGauge(t *testing.T) {
 	})
 
 	t.Run("valid spec", func(t *testing.T) {
-		gauge, err := s.NewGauge(Spec{
+		gauge, err := s.Gauge(Spec{
 			Name:      "test_gauge",
 			Help:      "Some help.",
 			ConstTags: Tags{"foo": "bar"},
@@ -74,7 +74,7 @@ func TestGaugeVector(t *testing.T) {
 			Help:    "Some help.",
 			VarTags: []string{"var"},
 		}
-		vec, err := root.Scope().NewGaugeVector(spec)
+		vec, err := root.Scope().GaugeVector(spec)
 		require.NoError(t, err, "Unexpected error constructing vector.")
 		return vec, root
 	}
@@ -125,7 +125,7 @@ func TestGaugeVectorConstructionErrors(t *testing.T) {
 	s := New().Scope()
 
 	t.Run("duplicate constant tag names", func(t *testing.T) {
-		_, err := s.NewGaugeVector(Spec{
+		_, err := s.GaugeVector(Spec{
 			Name:      "test_gauge",
 			Help:      "help",
 			ConstTags: Tags{"f_": "ok", "f&": "ok"}, // scrubbing introduces duplicate tag names
@@ -135,7 +135,7 @@ func TestGaugeVectorConstructionErrors(t *testing.T) {
 	})
 
 	t.Run("duplicate variable tag names", func(t *testing.T) {
-		_, err := s.NewGaugeVector(Spec{
+		_, err := s.GaugeVector(Spec{
 			Name:    "test_gauge",
 			Help:    "help",
 			VarTags: []string{"var", "var"},

--- a/histogram.go
+++ b/histogram.go
@@ -94,7 +94,8 @@ func newHistogram(m metadata, unit time.Duration, uppers []int64) *Histogram {
 }
 
 // Observe finds the correct bucket for the supplied duration and increments
-// its counter.
+// its counter. This is purely a convenience - it's equivalent to dividing the
+// duration by the histogram's unit and calling ObserveInt directly.
 func (h *Histogram) Observe(d time.Duration) {
 	if h == nil {
 		return
@@ -193,9 +194,8 @@ func (h *Histogram) push(target push.Target) {
 
 // A HistogramVector is a collection of Histograms that share a name and some
 // constant tags, but also have a consistent set of variable tags. All
-// exported methods are safe to use concurrently.
-//
-// A nil *HistogramVector is safe to use, and always returns no-op histograms.
+// exported methods are safe to use concurrently. Nil *HistogramVectors are
+// safe to use and always return no-op histograms.
 //
 // For a general description of vector types, see the package-level
 // documentation.

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -34,7 +34,7 @@ func TestHistogram(t *testing.T) {
 	s := root.Scope().Tagged(Tags{"service": "users"})
 
 	t.Run("duplicate constant tag names", func(t *testing.T) {
-		_, err := s.NewHistogram(HistogramSpec{
+		_, err := s.Histogram(HistogramSpec{
 			Spec: Spec{
 				Name:      "test_latency_ns",
 				Help:      "Some help.",
@@ -47,7 +47,7 @@ func TestHistogram(t *testing.T) {
 	})
 
 	t.Run("valid spec", func(t *testing.T) {
-		h, err := s.NewHistogram(HistogramSpec{
+		h, err := s.Histogram(HistogramSpec{
 			Spec: Spec{
 				Name:      "test_latency_ns",
 				Help:      "Some help.",
@@ -95,7 +95,7 @@ func TestHistogramVector(t *testing.T) {
 				Buckets: []int64{1000, 1000 * 60},
 			},
 			f: func(t testing.TB, s *Scope, spec HistogramSpec) {
-				vec, err := s.NewHistogramVector(spec)
+				vec, err := s.HistogramVector(spec)
 				require.NoError(t, err, "Unexpected error constructing vector.")
 				h, err := vec.Get("var", "x")
 				require.NoError(t, err, "Unexpected error getting a counter with correct number of tags.")
@@ -121,7 +121,7 @@ func TestHistogramVector(t *testing.T) {
 				Buckets: []int64{1000, 1000 * 60},
 			},
 			f: func(t testing.TB, s *Scope, spec HistogramSpec) {
-				vec, err := s.NewHistogramVector(spec)
+				vec, err := s.HistogramVector(spec)
 				require.NoError(t, err, "Unexpected error constructing vector.")
 				h, err := vec.Get("var", "x!")
 				require.NoError(t, err, "Unexpected error getting a counter with correct number of tags.")
@@ -147,7 +147,7 @@ func TestHistogramVector(t *testing.T) {
 				Buckets: []int64{1000, 1000 * 60},
 			},
 			f: func(t testing.TB, s *Scope, spec HistogramSpec) {
-				vec, err := s.NewHistogramVector(spec)
+				vec, err := s.HistogramVector(spec)
 				require.NoError(t, err, "Unexpected error constructing vector.")
 				_, err = vec.Get("var", "x", "var2", "y")
 				require.Error(t, err, "Unexpected success calling Get with incorrect number of tags.")
@@ -188,7 +188,7 @@ func TestHistogramVectorIndependence(t *testing.T) {
 		Unit:    time.Millisecond,
 		Buckets: []int64{1000},
 	}
-	vec, err := root.Scope().NewHistogramVector(spec)
+	vec, err := root.Scope().HistogramVector(spec)
 	require.NoError(t, err, "Unexpected error constructing vector.")
 
 	x, err := vec.Get("var", "x")

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -30,11 +30,11 @@ import (
 )
 
 func TestHistogram(t *testing.T) {
-	r, c := New()
-	r = r.Labeled(Labels{"service": "users"})
+	root := New()
+	s := root.Scope().Labeled(Labels{"service": "users"})
 
 	t.Run("duplicate constant label names", func(t *testing.T) {
-		_, err := r.NewHistogram(HistogramSpec{
+		_, err := s.NewHistogram(HistogramSpec{
 			Spec: Spec{
 				Name:   "test_latency_ns",
 				Help:   "Some help.",
@@ -47,7 +47,7 @@ func TestHistogram(t *testing.T) {
 	})
 
 	t.Run("valid spec", func(t *testing.T) {
-		h, err := r.NewHistogram(HistogramSpec{
+		h, err := s.NewHistogram(HistogramSpec{
 			Spec: Spec{
 				Name:   "test_latency_ns",
 				Help:   "Some help.",
@@ -64,7 +64,7 @@ func TestHistogram(t *testing.T) {
 		h.ObserveInt(75)
 		h.Observe(150)
 
-		snap := c.Snapshot()
+		snap := root.Snapshot()
 		require.Equal(t, 1, len(snap.Histograms), "Unexpected number of histogram snapshots.")
 		got := snap.Histograms[0]
 		assert.Equal(t, HistogramSnapshot{
@@ -80,7 +80,7 @@ func TestHistogramVector(t *testing.T) {
 	tests := []struct {
 		desc string
 		spec HistogramSpec
-		f    func(testing.TB, *Registry, HistogramSpec)
+		f    func(testing.TB, *Scope, HistogramSpec)
 		want HistogramSnapshot
 	}{
 		{
@@ -94,8 +94,8 @@ func TestHistogramVector(t *testing.T) {
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
 			},
-			f: func(t testing.TB, r *Registry, spec HistogramSpec) {
-				vec, err := r.NewHistogramVector(spec)
+			f: func(t testing.TB, s *Scope, spec HistogramSpec) {
+				vec, err := s.NewHistogramVector(spec)
 				require.NoError(t, err, "Unexpected error constructing vector.")
 				h, err := vec.Get("var", "x")
 				require.NoError(t, err, "Unexpected error getting a counter with correct number of labels.")
@@ -120,8 +120,8 @@ func TestHistogramVector(t *testing.T) {
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
 			},
-			f: func(t testing.TB, r *Registry, spec HistogramSpec) {
-				vec, err := r.NewHistogramVector(spec)
+			f: func(t testing.TB, s *Scope, spec HistogramSpec) {
+				vec, err := s.NewHistogramVector(spec)
 				require.NoError(t, err, "Unexpected error constructing vector.")
 				h, err := vec.Get("var", "x!")
 				require.NoError(t, err, "Unexpected error getting a counter with correct number of labels.")
@@ -146,8 +146,8 @@ func TestHistogramVector(t *testing.T) {
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
 			},
-			f: func(t testing.TB, r *Registry, spec HistogramSpec) {
-				vec, err := r.NewHistogramVector(spec)
+			f: func(t testing.TB, s *Scope, spec HistogramSpec) {
+				vec, err := s.NewHistogramVector(spec)
 				require.NoError(t, err, "Unexpected error constructing vector.")
 				_, err = vec.Get("var", "x", "var2", "y")
 				require.Error(t, err, "Unexpected success calling Get with incorrect number of labels.")
@@ -162,9 +162,9 @@ func TestHistogramVector(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			r, c := New()
-			tt.f(t, r, tt.spec)
-			snap := c.Snapshot()
+			root := New()
+			tt.f(t, root.Scope(), tt.spec)
+			snap := root.Snapshot()
 			if tt.want.Name != "" {
 				require.Equal(t, 1, len(snap.Histograms), "Unexpected number of histogram snapshots.")
 				assert.Equal(t, tt.want, snap.Histograms[0], "Unexpected histogram snapshot.")
@@ -178,7 +178,7 @@ func TestHistogramVector(t *testing.T) {
 func TestHistogramVectorIndependence(t *testing.T) {
 	// Ensure that we're not erroneously sharing state across histograms in a
 	// vector.
-	r, c := New()
+	root := New()
 	spec := HistogramSpec{
 		Spec: Spec{
 			Name:           "test_latency_ms",
@@ -188,7 +188,7 @@ func TestHistogramVectorIndependence(t *testing.T) {
 		Unit:    time.Millisecond,
 		Buckets: []int64{1000},
 	}
-	vec, err := r.NewHistogramVector(spec)
+	vec, err := root.Scope().NewHistogramVector(spec)
 	require.NoError(t, err, "Unexpected error constructing vector.")
 
 	x, err := vec.Get("var", "x")
@@ -200,7 +200,7 @@ func TestHistogramVectorIndependence(t *testing.T) {
 	x.Observe(time.Millisecond)
 	y.Observe(time.Millisecond)
 
-	snap := c.Snapshot()
+	snap := root.Snapshot()
 	require.Equal(t, 2, len(snap.Histograms), "Unexpected number of histogram snapshots.")
 
 	assert.Equal(t, HistogramSnapshot{

--- a/integration_test.go
+++ b/integration_test.go
@@ -41,7 +41,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 	root := New()
 	scope := root.Scope().Tagged(Tags{"service": "users"})
 
-	counter, err := scope.NewCounter(Spec{
+	counter, err := scope.Counter(Spec{
 		Name:        "test_counter",
 		Help:        "counter help",
 		ConstTags:   Tags{"foo": "counter"},
@@ -50,7 +50,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 	require.NoError(t, err, "Failed to create counter.")
 	counter.Inc()
 
-	counterVec, err := scope.NewCounterVector(Spec{
+	counterVec, err := scope.CounterVector(Spec{
 		Name:        "test_counter_vector",
 		Help:        "counter vector help",
 		ConstTags:   Tags{"foo": "counter_vector"},
@@ -67,7 +67,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 		"baz", "bazval2",
 	).Inc()
 
-	gauge, err := scope.NewGauge(Spec{
+	gauge, err := scope.Gauge(Spec{
 		Name:        "test_gauge",
 		Help:        "gauge help",
 		ConstTags:   Tags{"foo": "gauge"},
@@ -76,7 +76,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 	require.NoError(t, err, "Failed to create gauge.")
 	gauge.Store(42)
 
-	gaugeVec, err := scope.NewGaugeVector(Spec{
+	gaugeVec, err := scope.GaugeVector(Spec{
 		Name:        "test_gauge_vector",
 		Help:        "gauge vector help",
 		ConstTags:   Tags{"foo": "gauge_vector"},
@@ -93,7 +93,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 		"baz", "bazval2",
 	).Store(20)
 
-	hist, err := scope.NewHistogram(HistogramSpec{
+	hist, err := scope.Histogram(HistogramSpec{
 		Spec: Spec{
 			Name:        "test_histogram",
 			Help:        "histogram help",
@@ -106,7 +106,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 	require.NoError(t, err, "Failed to create histogram.")
 	hist.Observe(time.Millisecond)
 
-	histVec, err := scope.NewHistogramVector(HistogramSpec{
+	histVec, err := scope.HistogramVector(HistogramSpec{
 		Spec: Spec{
 			Name:        "test_histogram_vector",
 			Help:        "histogram vector help",

--- a/integration_test.go
+++ b/integration_test.go
@@ -39,23 +39,23 @@ import (
 
 func initializeMetrics(t testing.TB, disablePush bool) *Root {
 	root := New()
-	scope := root.Scope().Labeled(Labels{"service": "users"})
+	scope := root.Scope().Tagged(Tags{"service": "users"})
 
 	counter, err := scope.NewCounter(Spec{
 		Name:        "test_counter",
 		Help:        "counter help",
-		Labels:      Labels{"foo": "counter"},
+		ConstTags:   Tags{"foo": "counter"},
 		DisablePush: disablePush,
 	})
 	require.NoError(t, err, "Failed to create counter.")
 	counter.Inc()
 
 	counterVec, err := scope.NewCounterVector(Spec{
-		Name:           "test_counter_vector",
-		Help:           "counter vector help",
-		Labels:         Labels{"foo": "counter_vector"},
-		VariableLabels: []string{"quux", "baz"},
-		DisablePush:    disablePush,
+		Name:        "test_counter_vector",
+		Help:        "counter vector help",
+		ConstTags:   Tags{"foo": "counter_vector"},
+		VarTags:     []string{"quux", "baz"},
+		DisablePush: disablePush,
 	})
 	require.NoError(t, err, "Failed to create counter vector.")
 	counterVec.MustGet(
@@ -70,18 +70,18 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 	gauge, err := scope.NewGauge(Spec{
 		Name:        "test_gauge",
 		Help:        "gauge help",
-		Labels:      Labels{"foo": "gauge"},
+		ConstTags:   Tags{"foo": "gauge"},
 		DisablePush: disablePush,
 	})
 	require.NoError(t, err, "Failed to create gauge.")
 	gauge.Store(42)
 
 	gaugeVec, err := scope.NewGaugeVector(Spec{
-		Name:           "test_gauge_vector",
-		Help:           "gauge vector help",
-		Labels:         Labels{"foo": "gauge_vector"},
-		VariableLabels: []string{"quux", "baz"},
-		DisablePush:    disablePush,
+		Name:        "test_gauge_vector",
+		Help:        "gauge vector help",
+		ConstTags:   Tags{"foo": "gauge_vector"},
+		VarTags:     []string{"quux", "baz"},
+		DisablePush: disablePush,
 	})
 	require.NoError(t, err, "Failed to create gauge vector.")
 	gaugeVec.MustGet(
@@ -97,7 +97,7 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 		Spec: Spec{
 			Name:        "test_histogram",
 			Help:        "histogram help",
-			Labels:      Labels{"foo": "histogram"},
+			ConstTags:   Tags{"foo": "histogram"},
 			DisablePush: disablePush,
 		},
 		Unit:    time.Millisecond,
@@ -108,11 +108,11 @@ func initializeMetrics(t testing.TB, disablePush bool) *Root {
 
 	histVec, err := scope.NewHistogramVector(HistogramSpec{
 		Spec: Spec{
-			Name:           "test_histogram_vector",
-			Help:           "histogram vector help",
-			Labels:         Labels{"foo": "histogram_vector"},
-			VariableLabels: []string{"quux", "baz"},
-			DisablePush:    disablePush,
+			Name:        "test_histogram_vector",
+			Help:        "histogram vector help",
+			ConstTags:   Tags{"foo": "histogram_vector"},
+			VarTags:     []string{"quux", "baz"},
+			DisablePush: disablePush,
 		},
 		Unit:    time.Millisecond,
 		Buckets: []int64{1000, 1000 * 60},

--- a/metadata.go
+++ b/metadata.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Match the Prometheus error text.
-var errInconsistentCardinality = errors.New("inconsistent label cardinality")
+var errInconsistentCardinality = errors.New("inconsistent tag cardinality")
 
 // metadata stores our internal representation of metric specs. Adding this
 // layer of indirection between the user-facing specs and the metric
@@ -41,15 +41,15 @@ type metadata struct {
 	Dims        string
 	DisablePush bool
 
-	constPairs         []*promproto.LabelPair
-	variableLabelNames []string // unscrubbed
+	constTagPairs []*promproto.LabelPair
+	varTagNames   []string // unscrubbed
 }
 
 func newMetadata(o Spec) (metadata, error) {
-	// TODO: Consider checking for duplicate labels with Bloom filters,
-	// allocating maps only if we suspect a duplicate.
-	sortedConstNames := make([]string, 0, len(o.Labels))
-	for k := range o.Labels {
+	// TODO: Consider checking for duplicate tags with Bloom filters, allocating
+	// maps only if we suspect a duplicate.
+	sortedConstNames := make([]string, 0, len(o.ConstTags))
+	for k := range o.ConstTags {
 		sortedConstNames = append(sortedConstNames, k)
 	}
 	sort.Strings(sortedConstNames)
@@ -60,22 +60,22 @@ func newMetadata(o Spec) (metadata, error) {
 	for i, name := range sortedConstNames {
 		scrubbedName := scrubName(name)
 		if _, ok := constNameSet[scrubbedName]; ok {
-			return metadata{}, fmt.Errorf("duplicate constant label name %q", scrubbedName)
+			return metadata{}, fmt.Errorf("duplicate constant tag name %q", scrubbedName)
 		}
 		constNameSet[scrubbedName] = struct{}{}
 		sortedScrubbedConstNames[i] = scrubbedName
-		sortedScrubbedConstVals[i] = scrubLabelValue(o.Labels[name])
+		sortedScrubbedConstVals[i] = scrubTagValue(o.ConstTags[name])
 	}
 
-	varNameSet := make(map[string]struct{}, len(o.VariableLabels))
-	sortedScrubbedVarNames := make([]string, len(o.VariableLabels))
-	for i, name := range o.VariableLabels {
+	varNameSet := make(map[string]struct{}, len(o.VarTags))
+	sortedScrubbedVarNames := make([]string, len(o.VarTags))
+	for i, name := range o.VarTags {
 		scrubbedName := scrubName(name)
 		if _, ok := varNameSet[scrubbedName]; ok {
-			return metadata{}, fmt.Errorf("duplicate variable label name %q", scrubbedName)
+			return metadata{}, fmt.Errorf("duplicate variable tag name %q", scrubbedName)
 		}
 		if _, ok := constNameSet[scrubbedName]; ok {
-			return metadata{}, fmt.Errorf("variable label name %q is also a constant label name", scrubbedName)
+			return metadata{}, fmt.Errorf("variable tag name %q is also a constant tag name", scrubbedName)
 		}
 		varNameSet[scrubbedName] = struct{}{}
 		sortedScrubbedVarNames[i] = scrubbedName
@@ -94,26 +94,26 @@ func newMetadata(o Spec) (metadata, error) {
 	}
 	scrubbedName := scrubName(o.Name)
 	return metadata{
-		Name:               &scrubbedName,
-		Help:               &o.Help,
-		Dims:               makeDims(scrubbedName, sortedScrubbedConstNames, sortedScrubbedVarNames),
-		DisablePush:        o.DisablePush,
-		constPairs:         pairs,
-		variableLabelNames: o.VariableLabels, // preserve user-defined order
+		Name:          &scrubbedName,
+		Help:          &o.Help,
+		Dims:          makeDims(scrubbedName, sortedScrubbedConstNames, sortedScrubbedVarNames),
+		DisablePush:   o.DisablePush,
+		constTagPairs: pairs,
+		varTagNames:   o.VarTags, // preserve user-defined order
 	}, nil
 }
 
-//  merges variable and constant labels.
-func (m metadata) MergeLabels(variableLabels []string) []*promproto.LabelPair {
-	if len(variableLabels) == 0 {
-		return m.constPairs
+// MergeTags merges variable and constant tags.
+func (m metadata) MergeTags(variableTagPairs []string) []*promproto.LabelPair {
+	if len(variableTagPairs) == 0 {
+		return m.constTagPairs
 	}
-	n := len(m.constPairs) + len(m.variableLabelNames)
+	n := len(m.constTagPairs) + len(m.varTagNames)
 	pairs := make([]*promproto.LabelPair, 0, n)
-	pairs = append(pairs, m.constPairs...)
-	for i := range m.variableLabelNames { // user-supplied order was preserved
-		name := scrubName(m.variableLabelNames[i])
-		val := scrubLabelValue(variableLabels[i*2+1])
+	pairs = append(pairs, m.constTagPairs...)
+	for i := range m.varTagNames { // user-supplied order was preserved
+		name := scrubName(m.varTagNames[i])
+		val := scrubTagValue(variableTagPairs[i*2+1])
 		pairs = append(pairs, &promproto.LabelPair{
 			Name:  &name,
 			Value: &val,
@@ -125,19 +125,19 @@ func (m metadata) MergeLabels(variableLabels []string) []*promproto.LabelPair {
 	return pairs
 }
 
-// ValidateVariableLabels checks that the user-supplied variable label names
+// ValidateVariableTags checks that the user-supplied variable tag names
 // and values match the spec supplied at vector creation.
-func (m metadata) ValidateVariableLabels(variableLabels []string) error {
-	if len(variableLabels) != 2*len(m.variableLabelNames) {
+func (m metadata) ValidateVariableTags(variableTagPairs []string) error {
+	if len(variableTagPairs) != 2*len(m.varTagNames) {
 		return errInconsistentCardinality
 	}
-	for i, expected := range m.variableLabelNames { // user-supplied order was preserved
-		if expected != variableLabels[i*2] {
+	for i, expected := range m.varTagNames { // user-supplied order was preserved
+		if expected != variableTagPairs[i*2] {
 			return fmt.Errorf(
-				"variable label #%d doesn't match vector definition: expected %s, got %s",
+				"variable tag #%d doesn't match vector definition: expected %s, got %s",
 				i,
 				expected,
-				variableLabels[i*2],
+				variableTagPairs[i*2],
 			)
 		}
 	}
@@ -149,14 +149,14 @@ func (m metadata) ValidateVariableLabels(variableLabels []string) error {
 // allocating a string for each ID.
 func (m metadata) writeID(d *digester) {
 	d.add("", *m.Name)
-	for _, pair := range m.constPairs {
+	for _, pair := range m.constTagPairs {
 		d.add("", pair.GetName())
 		d.add("", pair.GetValue())
 	}
 }
 
 // makeDims creates a string representation of the metric's dimensions (name,
-// constant label names, and variable label names). It's used as a map value,
+// constant tag names, and variable tag names). It's used as a map value,
 // so we can't avoid this allocation.
 func makeDims(name string, constNames, sortedVarNames []string) string {
 	d := newDigester()
@@ -165,8 +165,8 @@ func makeDims(name string, constNames, sortedVarNames []string) string {
 		d.add("", n)
 	}
 	for _, n := range sortedVarNames {
-		// To make sure that we can tell whether a given label name is constant or
-		// variable, prefix variable label names with a character that's otherwise
+		// To make sure that we can tell whether a given tag name is constant or
+		// variable, prefix variable tag names with a character that's otherwise
 		// forbidden.
 		d.add("$", n)
 	}

--- a/metrics.go
+++ b/metrics.go
@@ -25,18 +25,6 @@ import (
 	"go.uber.org/net/metrics/push"
 )
 
-// An Option configures registries and controllers. Currently, there are no
-// exported Options.
-type Option interface {
-	unimplemented()
-}
-
-// New constructs a Registry and Controller.
-func New(opts ...Option) (*Registry, *Controller) {
-	core := newCoreRegistry()
-	return newRegistry(core, Labels{}), newController(core)
-}
-
 type metric interface {
 	describe() metadata
 	proto() *promproto.MetricFamily

--- a/nop_test.go
+++ b/nop_test.go
@@ -55,27 +55,27 @@ func TestNopHistogramVector(t *testing.T) {
 func TestNopScope(t *testing.T) {
 	var s *Scope
 	s = s.Tagged(Tags{"foo": "bar"})
-	c, err := s.NewCounter(Spec{})
-	assert.NoError(t, err, "Error calling NewCounter on nil Registry.")
+	c, err := s.Counter(Spec{})
+	assert.NoError(t, err, "Error calling Counter on nil scope.")
 	assertNopCounter(t, c)
 
-	cv, err := s.NewCounterVector(Spec{})
-	assert.NoError(t, err, "Error calling NewCounterVector on nil Registry.")
+	cv, err := s.CounterVector(Spec{})
+	assert.NoError(t, err, "Error calling CounterVector on nil scope.")
 	assertNopCounterVector(t, cv)
 
-	g, err := s.NewGauge(Spec{})
-	assert.NoError(t, err, "Error calling NewGauge on nil Registry.")
+	g, err := s.Gauge(Spec{})
+	assert.NoError(t, err, "Error calling Gauge on nil scope.")
 	assertNopGauge(t, g)
 
-	gv, err := s.NewGaugeVector(Spec{})
-	assert.NoError(t, err, "Error calling NewGaugeVector on nil Registry.")
+	gv, err := s.GaugeVector(Spec{})
+	assert.NoError(t, err, "Error calling GaugeVector on nil scope.")
 	assertNopGaugeVector(t, gv)
 
-	h, err := s.NewHistogram(HistogramSpec{})
-	assert.NoError(t, err, "Error calling NewHistogram on nil Registry.")
+	h, err := s.Histogram(HistogramSpec{})
+	assert.NoError(t, err, "Error calling Histogram on nil scope.")
 	assertNopHistogram(t, h)
 
-	hv, err := s.NewHistogramVector(HistogramSpec{})
+	hv, err := s.HistogramVector(HistogramSpec{})
 	assertNopHistogramVector(t, hv)
 }
 

--- a/nop_test.go
+++ b/nop_test.go
@@ -54,7 +54,7 @@ func TestNopHistogramVector(t *testing.T) {
 
 func TestNopScope(t *testing.T) {
 	var s *Scope
-	s = s.Labeled(Labels{"foo": "bar"})
+	s = s.Tagged(Tags{"foo": "bar"})
 	c, err := s.NewCounter(Spec{})
 	assert.NoError(t, err, "Error calling NewCounter on nil Registry.")
 	assertNopCounter(t, c)

--- a/nop_test.go
+++ b/nop_test.go
@@ -52,30 +52,30 @@ func TestNopHistogramVector(t *testing.T) {
 	assertNopHistogramVector(t, nil)
 }
 
-func TestNopRegistry(t *testing.T) {
-	var r *Registry
-	r = r.Labeled(Labels{"foo": "bar"})
-	c, err := r.NewCounter(Spec{})
+func TestNopScope(t *testing.T) {
+	var s *Scope
+	s = s.Labeled(Labels{"foo": "bar"})
+	c, err := s.NewCounter(Spec{})
 	assert.NoError(t, err, "Error calling NewCounter on nil Registry.")
 	assertNopCounter(t, c)
 
-	cv, err := r.NewCounterVector(Spec{})
+	cv, err := s.NewCounterVector(Spec{})
 	assert.NoError(t, err, "Error calling NewCounterVector on nil Registry.")
 	assertNopCounterVector(t, cv)
 
-	g, err := r.NewGauge(Spec{})
+	g, err := s.NewGauge(Spec{})
 	assert.NoError(t, err, "Error calling NewGauge on nil Registry.")
 	assertNopGauge(t, g)
 
-	gv, err := r.NewGaugeVector(Spec{})
+	gv, err := s.NewGaugeVector(Spec{})
 	assert.NoError(t, err, "Error calling NewGaugeVector on nil Registry.")
 	assertNopGaugeVector(t, gv)
 
-	h, err := r.NewHistogram(HistogramSpec{})
+	h, err := s.NewHistogram(HistogramSpec{})
 	assert.NoError(t, err, "Error calling NewHistogram on nil Registry.")
 	assertNopHistogram(t, h)
 
-	hv, err := r.NewHistogramVector(HistogramSpec{})
+	hv, err := s.NewHistogramVector(HistogramSpec{})
 	assertNopHistogramVector(t, hv)
 }
 

--- a/push.go
+++ b/push.go
@@ -27,14 +27,14 @@ import (
 )
 
 type pusher struct {
-	core    *coreRegistry
+	core    *core
 	stop    chan struct{}
 	stopped chan struct{}
 	ticker  *time.Ticker
 	target  push.Target
 }
 
-func newPusher(c *coreRegistry, target push.Target, tick time.Duration) *pusher {
+func newPusher(c *core, target push.Target, tick time.Duration) *pusher {
 	return &pusher{
 		core:    c,
 		stop:    make(chan struct{}),

--- a/push/push.go
+++ b/push/push.go
@@ -20,9 +20,9 @@
 
 package push // import "go.uber.org/net/metrics/push"
 
-// A Target bridges the net/metrics representations of counters, gauges, and
-// histograms with push-based telemetry systems. Targets are designed to work
-// with the metrics.Controller struct's Push method, so they don't need to be
+// A Target bridges the metrics package's representations of counters, gauges,
+// and histograms with push-based telemetry systems. Targets are designed to
+// work with the metrics.Root struct's Push method, so they don't need to be
 // safe for concurrent use.
 //
 // A concrete implementation of this interface that works with StatsD and M3

--- a/push/push.go
+++ b/push/push.go
@@ -35,8 +35,8 @@ type Target interface {
 
 // A Spec configures counters and gauges.
 type Spec struct {
-	Name   string
-	Labels map[string]string
+	Name string
+	Tags map[string]string
 }
 
 // A HistogramSpec configures histograms.

--- a/registry_test.go
+++ b/registry_test.go
@@ -352,7 +352,7 @@ func TestLabeledPrecedence(t *testing.T) {
 	require.NoError(t, err, "Failed to create counter.")
 	snap := c.Snapshot()
 	require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
-	assert.Equal(t, SimpleSnapshot{
+	assert.Equal(t, Snapshot{
 		Name:   "test_counter",
 		Labels: Labels{"foo": "baz"},
 	}, snap.Counters[0], "Unexpected counter snapshot.")
@@ -375,7 +375,7 @@ func TestLabeledAutoScrubbing(t *testing.T) {
 	require.NoError(t, err, "Failed to create counter.")
 	snap := c.Snapshot()
 	require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
-	assert.Equal(t, SimpleSnapshot{
+	assert.Equal(t, Snapshot{
 		Name: "test_counter",
 		Labels: Labels{
 			"invalid_prometheus_name": "foo",

--- a/root.go
+++ b/root.go
@@ -53,7 +53,7 @@ func New(opts ...Option) *Root {
 	core := newCore()
 	return &Root{
 		core:  core,
-		scope: newScope(core, Labels{}),
+		scope: newScope(core, Tags{}),
 		handler: promhttp.HandlerFor(core.gatherer, promhttp.HandlerOpts{
 			ErrorHandling: promhttp.HTTPErrorOnError, // 500 on errors
 		}),

--- a/scope.go
+++ b/scope.go
@@ -33,9 +33,9 @@ func newScope(c *core, tags Tags) *Scope {
 	}
 }
 
-// Tagged creates a new Registry with new constant tags appended to the
-// current Registry's existing tags. Tag names and values are automatically
-// scrubbed, with invalid characters replaced by underscores.
+// Tagged creates a new scope with new constant tags merged into the existing
+// tags (if any). Tag names and values are automatically scrubbed, with
+// invalid characters replaced by underscores.
 func (s *Scope) Tagged(tags Tags) *Scope {
 	if s == nil {
 		return nil

--- a/scope.go
+++ b/scope.go
@@ -22,32 +22,32 @@ package metrics
 
 // A Scope is a collection of tagged metrics.
 type Scope struct {
-	core        *core
-	constLabels Labels
+	core      *core
+	constTags Tags
 }
 
-func newScope(c *core, labels Labels) *Scope {
+func newScope(c *core, tags Tags) *Scope {
 	return &Scope{
-		core:        c,
-		constLabels: labels,
+		core:      c,
+		constTags: tags,
 	}
 }
 
-// Labeled creates a new Registry with new constant labels appended to the
-// current Registry's existing labels. Label names and values are
-// automatically scrubbed, with invalid characters replaced by underscores.
-func (s *Scope) Labeled(ls Labels) *Scope {
+// Tagged creates a new Registry with new constant tags appended to the
+// current Registry's existing tags. Tag names and values are automatically
+// scrubbed, with invalid characters replaced by underscores.
+func (s *Scope) Tagged(tags Tags) *Scope {
 	if s == nil {
 		return nil
 	}
-	newLabels := make(Labels, len(s.constLabels)+len(ls))
-	for k, v := range s.constLabels {
-		newLabels[k] = v
+	newTags := make(Tags, len(s.constTags)+len(tags))
+	for k, v := range s.constTags {
+		newTags[k] = v
 	}
-	for k, v := range ls {
-		newLabels[scrubName(k)] = scrubLabelValue(v)
+	for k, v := range tags {
+		newTags[scrubName(k)] = scrubTagValue(v)
 	}
-	return newScope(s.core, newLabels)
+	return newScope(s.core, newTags)
 }
 
 // NewCounter constructs a new Counter.
@@ -55,7 +55,7 @@ func (s *Scope) NewCounter(spec Spec) (*Counter, error) {
 	if s == nil {
 		return nil, nil
 	}
-	spec = s.addConstLabels(spec)
+	spec = s.addConstTags(spec)
 	if err := spec.validateScalar(); err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (s *Scope) NewGauge(spec Spec) (*Gauge, error) {
 	if s == nil {
 		return nil, nil
 	}
-	spec = s.addConstLabels(spec)
+	spec = s.addConstTags(spec)
 	if err := spec.validateScalar(); err != nil {
 		return nil, err
 	}
@@ -95,7 +95,7 @@ func (s *Scope) NewHistogram(spec HistogramSpec) (*Histogram, error) {
 	if s == nil {
 		return nil, nil
 	}
-	spec.Spec = s.addConstLabels(spec.Spec)
+	spec.Spec = s.addConstTags(spec.Spec)
 	if err := spec.validateScalar(); err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func (s *Scope) NewCounterVector(spec Spec) (*CounterVector, error) {
 	if s == nil {
 		return nil, nil
 	}
-	spec = s.addConstLabels(spec)
+	spec = s.addConstTags(spec)
 	if err := spec.validateVector(); err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func (s *Scope) NewGaugeVector(spec Spec) (*GaugeVector, error) {
 	if s == nil {
 		return nil, nil
 	}
-	spec = s.addConstLabels(spec)
+	spec = s.addConstTags(spec)
 	if err := spec.validateVector(); err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (s *Scope) NewHistogramVector(spec HistogramSpec) (*HistogramVector, error)
 	if s == nil {
 		return nil, nil
 	}
-	spec.Spec = s.addConstLabels(spec.Spec)
+	spec.Spec = s.addConstTags(spec.Spec)
 	if err := spec.validateVector(); err != nil {
 		return nil, err
 	}
@@ -170,17 +170,17 @@ func (s *Scope) NewHistogramVector(spec HistogramSpec) (*HistogramVector, error)
 	return hv, nil
 }
 
-func (s *Scope) addConstLabels(spec Spec) Spec {
-	if len(s.constLabels) == 0 {
+func (s *Scope) addConstTags(spec Spec) Spec {
+	if len(s.constTags) == 0 {
 		return spec
 	}
-	labels := make(Labels, len(s.constLabels)+len(spec.Labels))
-	for k, v := range s.constLabels {
-		labels[k] = v
+	tags := make(Tags, len(s.constTags)+len(spec.ConstTags))
+	for k, v := range s.constTags {
+		tags[k] = v
 	}
-	for k, v := range spec.Labels {
-		labels[k] = v
+	for k, v := range spec.ConstTags {
+		tags[k] = v
 	}
-	spec.Labels = labels
+	spec.ConstTags = tags
 	return spec
 }

--- a/scope.go
+++ b/scope.go
@@ -50,8 +50,8 @@ func (s *Scope) Tagged(tags Tags) *Scope {
 	return newScope(s.core, newTags)
 }
 
-// NewCounter constructs a new Counter.
-func (s *Scope) NewCounter(spec Spec) (*Counter, error) {
+// Counter constructs a new Counter.
+func (s *Scope) Counter(spec Spec) (*Counter, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -70,8 +70,8 @@ func (s *Scope) NewCounter(spec Spec) (*Counter, error) {
 	return c, nil
 }
 
-// NewGauge constructs a new Gauge.
-func (s *Scope) NewGauge(spec Spec) (*Gauge, error) {
+// Gauge constructs a new Gauge.
+func (s *Scope) Gauge(spec Spec) (*Gauge, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -90,8 +90,8 @@ func (s *Scope) NewGauge(spec Spec) (*Gauge, error) {
 	return g, nil
 }
 
-// NewHistogram constructs a new Histogram.
-func (s *Scope) NewHistogram(spec HistogramSpec) (*Histogram, error) {
+// Histogram constructs a new Histogram.
+func (s *Scope) Histogram(spec HistogramSpec) (*Histogram, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -110,8 +110,8 @@ func (s *Scope) NewHistogram(spec HistogramSpec) (*Histogram, error) {
 	return h, nil
 }
 
-// NewCounterVector constructs a new CounterVector.
-func (s *Scope) NewCounterVector(spec Spec) (*CounterVector, error) {
+// CounterVector constructs a new CounterVector.
+func (s *Scope) CounterVector(spec Spec) (*CounterVector, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -130,8 +130,8 @@ func (s *Scope) NewCounterVector(spec Spec) (*CounterVector, error) {
 	return cv, nil
 }
 
-// NewGaugeVector constructs a new GaugeVector.
-func (s *Scope) NewGaugeVector(spec Spec) (*GaugeVector, error) {
+// GaugeVector constructs a new GaugeVector.
+func (s *Scope) GaugeVector(spec Spec) (*GaugeVector, error) {
 	if s == nil {
 		return nil, nil
 	}
@@ -150,8 +150,8 @@ func (s *Scope) NewGaugeVector(spec Spec) (*GaugeVector, error) {
 	return gv, nil
 }
 
-// NewHistogramVector constructs a new HistogramVector.
-func (s *Scope) NewHistogramVector(spec HistogramSpec) (*HistogramVector, error) {
+// HistogramVector constructs a new HistogramVector.
+func (s *Scope) HistogramVector(spec HistogramSpec) (*HistogramVector, error) {
 	if s == nil {
 		return nil, nil
 	}

--- a/scope_test.go
+++ b/scope_test.go
@@ -29,25 +29,25 @@ import (
 )
 
 func TestScalarMetricDuplicates(t *testing.T) {
-	r, _ := New()
+	scope := New().Scope()
 	spec := Spec{
 		Name: "foo",
 		Help: "help",
 	}
-	_, err := r.NewCounter(spec)
+	_, err := scope.NewCounter(spec)
 	assert.NoError(t, err, "Failed first registration.")
 
 	t.Run("same type", func(t *testing.T) {
 		// You can't reuse specs with the same metric type.
-		_, err := r.NewCounter(spec)
+		_, err := scope.NewCounter(spec)
 		assert.Error(t, err)
 	})
 
 	t.Run("different type", func(t *testing.T) {
 		// Even if you change the metric type, you still can't re-use metadata.
-		_, err := r.NewGauge(spec)
+		_, err := scope.NewGauge(spec)
 		assert.Error(t, err)
-		_, err = r.NewHistogram(HistogramSpec{
+		_, err = scope.NewHistogram(HistogramSpec{
 			Spec:    spec,
 			Unit:    time.Nanosecond,
 			Buckets: []int64{1, 2},
@@ -57,7 +57,7 @@ func TestScalarMetricDuplicates(t *testing.T) {
 
 	t.Run("different help", func(t *testing.T) {
 		// Changing the help string doesn't change the metric's identity.
-		_, err := r.NewCounter(Spec{
+		_, err := scope.NewCounter(Spec{
 			Name: "foo",
 			Help: "different help",
 		})
@@ -66,7 +66,7 @@ func TestScalarMetricDuplicates(t *testing.T) {
 
 	t.Run("added dimensions", func(t *testing.T) {
 		// Can't have the same metric name with added dimensions.
-		_, err := r.NewCounter(Spec{
+		_, err := scope.NewCounter(Spec{
 			Name:   "foo",
 			Help:   "help",
 			Labels: Labels{"bar": "baz"},
@@ -77,13 +77,13 @@ func TestScalarMetricDuplicates(t *testing.T) {
 	t.Run("different dimensions", func(t *testing.T) {
 		// Even if the number of dimensions is the same, metrics with the same
 		// name must have the same dimensions.
-		_, err := r.NewCounter(Spec{
+		_, err := scope.NewCounter(Spec{
 			Name:   "dimensions",
 			Help:   "help",
 			Labels: Labels{"bar": "baz"},
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = r.NewCounter(Spec{
+		_, err = scope.NewCounter(Spec{
 			Name:   "dimensions",
 			Help:   "help",
 			Labels: Labels{"bing": "quux"},
@@ -96,7 +96,7 @@ func TestScalarMetricDuplicates(t *testing.T) {
 		// change. This allows users to (inefficiently) create what are
 		// effectively vectors - a collection of metrics with the same name and
 		// label names, but different label values.
-		_, err := r.NewCounter(Spec{
+		_, err := scope.NewCounter(Spec{
 			Name:   "dimensions",
 			Help:   "help",
 			Labels: Labels{"bar": "quux"},
@@ -106,12 +106,12 @@ func TestScalarMetricDuplicates(t *testing.T) {
 
 	t.Run("duplicate scrubbed name", func(t *testing.T) {
 		// Uniqueness is enforced after the metric name is scrubbed.
-		_, err := r.NewCounter(Spec{
+		_, err := scope.NewCounter(Spec{
 			Name: "scrubbed_name",
 			Help: "help",
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = r.NewCounter(Spec{
+		_, err = scope.NewCounter(Spec{
 			Name: "scrubbed&name",
 			Help: "help",
 		})
@@ -120,13 +120,13 @@ func TestScalarMetricDuplicates(t *testing.T) {
 
 	t.Run("duplicate scrubbed dimensions", func(t *testing.T) {
 		// Uniqueness is enforced after labels are scrubbed.
-		_, err := r.NewCounter(Spec{
+		_, err := scope.NewCounter(Spec{
 			Name:   "scrubbed_dimensions",
 			Help:   "help",
 			Labels: Labels{"b_r": "baz"},
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = r.NewCounter(Spec{
+		_, err = scope.NewCounter(Spec{
 			Name:   "scrubbed_dimensions",
 			Help:   "help",
 			Labels: Labels{"b&r": "baz"},
@@ -137,7 +137,7 @@ func TestScalarMetricDuplicates(t *testing.T) {
 	t.Run("constant label name specified twice", func(t *testing.T) {
 		// Within a single user-supplied set of labels, scrubbing may not
 		// introduce duplicates.
-		_, err = r.NewCounter(Spec{
+		_, err = scope.NewCounter(Spec{
 			Name:   "user_error_constant_labels",
 			Help:   "help",
 			Labels: Labels{"b_r": "baz", "b&r": "baz"},
@@ -147,26 +147,26 @@ func TestScalarMetricDuplicates(t *testing.T) {
 }
 
 func TestVectorMetricDuplicates(t *testing.T) {
-	r, _ := New()
+	scope := New().Scope()
 	spec := Spec{
 		Name:           "foo",
 		Help:           "help",
 		VariableLabels: []string{"foo"},
 	}
-	_, err := r.NewCounterVector(spec)
+	_, err := scope.NewCounterVector(spec)
 	assert.NoError(t, err, "Failed first registration.")
 
 	t.Run("same type", func(t *testing.T) {
 		// You can't reuse specs with the same metric type.
-		_, err := r.NewCounterVector(spec)
+		_, err := scope.NewCounterVector(spec)
 		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
 	})
 
 	t.Run("different type", func(t *testing.T) {
 		// Even if you change the metric type, you still can't re-use metadata.
-		_, err := r.NewGaugeVector(spec)
+		_, err := scope.NewGaugeVector(spec)
 		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
-		_, err = r.NewHistogramVector(HistogramSpec{
+		_, err = scope.NewHistogramVector(HistogramSpec{
 			Spec:    spec,
 			Unit:    time.Nanosecond,
 			Buckets: []int64{1, 2},
@@ -177,14 +177,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("different type and mixed labels", func(t *testing.T) {
 		// If we change the type and make some constant labels variable, we still
 		// can't re-use metadata.
-		_, err := r.NewCounterVector(Spec{
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "test_different_type_mixed_labels",
 			Help:           "help",
 			Labels:         Labels{"foo": "ok"},
 			VariableLabels: []string{"bar"},
 		})
 		require.NoError(t, err, "Failed to create initial metric.")
-		_, err = r.NewGaugeVector(Spec{
+		_, err = scope.NewGaugeVector(Spec{
 			Name:           "test_different_type_mixed_labels",
 			Help:           "help",
 			VariableLabels: []string{"foo", "bar"},
@@ -194,7 +194,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 
 	t.Run("different help", func(t *testing.T) {
 		// Changing the help string doesn't change the metric's identity.
-		_, err := r.NewCounterVector(Spec{
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "foo",
 			Help:           "different help",
 			VariableLabels: []string{"foo"},
@@ -204,14 +204,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 
 	t.Run("added dimensions", func(t *testing.T) {
 		// Can't have the same metric name with added dimensions.
-		_, err := r.NewCounterVector(Spec{
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "foo",
 			Help:           "help",
 			VariableLabels: []string{"foo"},
 			Labels:         Labels{"bar": "baz"},
 		})
 		assert.Error(t, err, "Shouldn't be able to add constant labels.")
-		_, err = r.NewCounterVector(Spec{
+		_, err = scope.NewCounterVector(Spec{
 			Name:           "foo",
 			Help:           "help",
 			VariableLabels: []string{"foo", "bar"},
@@ -222,7 +222,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("different dimensions", func(t *testing.T) {
 		// Even if the number of dimensions is the same, metrics with the same
 		// name must have the same dimensions.
-		_, err := r.NewCounterVector(Spec{
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "foo",
 			Help:           "help",
 			VariableLabels: []string{"bar"},
@@ -234,14 +234,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 		// If a metric has the same name and dimensions, the label values
 		// may change. (Again, this would be more efficiently modeled as a
 		// higher-dimensionality vector.)
-		_, err := r.NewCounterVector(Spec{
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "dimensions",
 			Help:           "help",
 			Labels:         Labels{"bar": "baz"},
 			VariableLabels: []string{"foo"},
 		})
 		assert.NoError(t, err)
-		_, err = r.NewCounterVector(Spec{
+		_, err = scope.NewCounterVector(Spec{
 			Name:           "dimensions",
 			Help:           "help",
 			Labels:         Labels{"bar": "quux"},
@@ -257,7 +257,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 		// carte scalars.
 
 		// dims: foo, baz
-		_, err := r.NewCounterVector(Spec{
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "ownership",
 			Help:           "help",
 			Labels:         Labels{"foo": "bar"},
@@ -266,7 +266,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 		require.NoError(t, err)
 
 		// same dims
-		_, err = r.NewCounter(Spec{
+		_, err = scope.NewCounter(Spec{
 			Name:   "ownership",
 			Help:   "help",
 			Labels: Labels{"foo": "bar", "baz": "quux"},
@@ -276,13 +276,13 @@ func TestVectorMetricDuplicates(t *testing.T) {
 
 	t.Run("duplicate scrubbed name", func(t *testing.T) {
 		// Uniqueness is enforced after the metric name is scrubbed.
-		_, err := r.NewCounterVector(Spec{
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "scrubbed_name",
 			Help:           "help",
 			VariableLabels: []string{"bar"},
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = r.NewCounterVector(Spec{
+		_, err = scope.NewCounterVector(Spec{
 			Name:           "scrubbed&name",
 			Help:           "help",
 			VariableLabels: []string{"bar"},
@@ -292,14 +292,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 
 	t.Run("duplicate scrubbed dimensions", func(t *testing.T) {
 		// Uniqueness is enforced after labels are scrubbed.
-		_, err := r.NewCounterVector(Spec{
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "scrubbed_dimensions",
 			Help:           "help",
 			Labels:         Labels{"b_r": "baz"},
 			VariableLabels: []string{"q__x"},
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = r.NewCounterVector(Spec{
+		_, err = scope.NewCounterVector(Spec{
 			Name:           "scrubbed_dimensions",
 			Help:           "help",
 			Labels:         Labels{"b&r": "baz"},
@@ -311,7 +311,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("constant label name specified twice", func(t *testing.T) {
 		// Within a single user-supplied set of constant labels, scrubbing may not
 		// introduce duplicates.
-		_, err = r.NewCounterVector(Spec{
+		_, err = scope.NewCounterVector(Spec{
 			Name:           "user_error_constant_labels",
 			Help:           "help",
 			Labels:         Labels{"b_r": "baz", "b&r": "baz"},
@@ -323,7 +323,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("variable label name specified twice", func(t *testing.T) {
 		// Within a single user-supplied set of variable labels, scrubbing may not
 		// introduce duplicates.
-		_, err = r.NewCounterVector(Spec{
+		_, err = scope.NewCounterVector(Spec{
 			Name:           "user_error_variable_labels",
 			Help:           "help",
 			VariableLabels: []string{"f__", "f&&"},
@@ -332,7 +332,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	})
 
 	t.Run("constant and variable label name overlap", func(t *testing.T) {
-		_, err = r.NewCounterVector(Spec{
+		_, err = scope.NewCounterVector(Spec{
 			Name:           "user_error_label_overlaps",
 			Help:           "help",
 			Labels:         Labels{"foo": "one"},
@@ -343,14 +343,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 }
 
 func TestLabeledPrecedence(t *testing.T) {
-	r, c := New()
-	r = r.Labeled(Labels{"foo": "bar"}).Labeled(Labels{"foo": "baz"})
-	_, err := r.NewCounter(Spec{
+	root := New()
+	scope := root.Scope().Labeled(Labels{"foo": "bar"}).Labeled(Labels{"foo": "baz"})
+	_, err := scope.NewCounter(Spec{
 		Name: "test_counter",
 		Help: "help",
 	})
 	require.NoError(t, err, "Failed to create counter.")
-	snap := c.Snapshot()
+	snap := root.Snapshot()
 	require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
 	assert.Equal(t, Snapshot{
 		Name:   "test_counter",
@@ -359,13 +359,13 @@ func TestLabeledPrecedence(t *testing.T) {
 }
 
 func TestLabeledAutoScrubbing(t *testing.T) {
-	r, c := New()
-	r = r.Labeled(Labels{
+	root := New()
+	scope := root.Scope().Labeled(Labels{
 		"invalid-prometheus-name": "foo",
 		"tally":                   "invalid!value",
 		"valid":                   "ok",
 	})
-	vec, err := r.NewCounterVector(Spec{
+	vec, err := scope.NewCounterVector(Spec{
 		Name:           "test_counter",
 		Help:           "help",
 		VariableLabels: []string{"invalid_var_name!"},
@@ -373,7 +373,7 @@ func TestLabeledAutoScrubbing(t *testing.T) {
 	vec.MustGet("invalid_var_name!", "ok").Inc()
 
 	require.NoError(t, err, "Failed to create counter.")
-	snap := c.Snapshot()
+	snap := root.Snapshot()
 	require.Equal(t, 1, len(snap.Counters), "Unexpected number of counters.")
 	assert.Equal(t, Snapshot{
 		Name: "test_counter",
@@ -389,8 +389,8 @@ func TestLabeledAutoScrubbing(t *testing.T) {
 
 func TestLabelScrubbingUniqueness(t *testing.T) {
 	t.Run("duplicate const names", func(t *testing.T) {
-		r, _ := New()
-		_, err := r.NewCounter(Spec{
+		scope := New().Scope()
+		_, err := scope.NewCounter(Spec{
 			Name: "test",
 			Help: "help",
 			Labels: Labels{
@@ -401,8 +401,8 @@ func TestLabelScrubbingUniqueness(t *testing.T) {
 		assert.Error(t, err, "Expected error when scrubbing duplicates label names.")
 	})
 	t.Run("duplicate variable names", func(t *testing.T) {
-		r, _ := New()
-		_, err := r.NewCounterVector(Spec{
+		scope := New().Scope()
+		_, err := scope.NewCounterVector(Spec{
 			Name:           "test",
 			Help:           "help",
 			VariableLabels: []string{"foo_bar", "foo!bar"},

--- a/scope_test.go
+++ b/scope_test.go
@@ -34,20 +34,20 @@ func TestScalarMetricDuplicates(t *testing.T) {
 		Name: "foo",
 		Help: "help",
 	}
-	_, err := scope.NewCounter(spec)
+	_, err := scope.Counter(spec)
 	assert.NoError(t, err, "Failed first registration.")
 
 	t.Run("same type", func(t *testing.T) {
 		// You can't reuse specs with the same metric type.
-		_, err := scope.NewCounter(spec)
+		_, err := scope.Counter(spec)
 		assert.Error(t, err)
 	})
 
 	t.Run("different type", func(t *testing.T) {
 		// Even if you change the metric type, you still can't re-use metadata.
-		_, err := scope.NewGauge(spec)
+		_, err := scope.Gauge(spec)
 		assert.Error(t, err)
-		_, err = scope.NewHistogram(HistogramSpec{
+		_, err = scope.Histogram(HistogramSpec{
 			Spec:    spec,
 			Unit:    time.Nanosecond,
 			Buckets: []int64{1, 2},
@@ -57,7 +57,7 @@ func TestScalarMetricDuplicates(t *testing.T) {
 
 	t.Run("different help", func(t *testing.T) {
 		// Changing the help string doesn't change the metric's identity.
-		_, err := scope.NewCounter(Spec{
+		_, err := scope.Counter(Spec{
 			Name: "foo",
 			Help: "different help",
 		})
@@ -66,7 +66,7 @@ func TestScalarMetricDuplicates(t *testing.T) {
 
 	t.Run("added dimensions", func(t *testing.T) {
 		// Can't have the same metric name with added dimensions.
-		_, err := scope.NewCounter(Spec{
+		_, err := scope.Counter(Spec{
 			Name:      "foo",
 			Help:      "help",
 			ConstTags: Tags{"bar": "baz"},
@@ -77,13 +77,13 @@ func TestScalarMetricDuplicates(t *testing.T) {
 	t.Run("different dimensions", func(t *testing.T) {
 		// Even if the number of dimensions is the same, metrics with the same
 		// name must have the same dimensions.
-		_, err := scope.NewCounter(Spec{
+		_, err := scope.Counter(Spec{
 			Name:      "dimensions",
 			Help:      "help",
 			ConstTags: Tags{"bar": "baz"},
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = scope.NewCounter(Spec{
+		_, err = scope.Counter(Spec{
 			Name:      "dimensions",
 			Help:      "help",
 			ConstTags: Tags{"bing": "quux"},
@@ -96,7 +96,7 @@ func TestScalarMetricDuplicates(t *testing.T) {
 		// change. This allows users to (inefficiently) create what are
 		// effectively vectors - a collection of metrics with the same name and
 		// tag names, but different tag values.
-		_, err := scope.NewCounter(Spec{
+		_, err := scope.Counter(Spec{
 			Name:      "dimensions",
 			Help:      "help",
 			ConstTags: Tags{"bar": "quux"},
@@ -106,12 +106,12 @@ func TestScalarMetricDuplicates(t *testing.T) {
 
 	t.Run("duplicate scrubbed name", func(t *testing.T) {
 		// Uniqueness is enforced after the metric name is scrubbed.
-		_, err := scope.NewCounter(Spec{
+		_, err := scope.Counter(Spec{
 			Name: "scrubbed_name",
 			Help: "help",
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = scope.NewCounter(Spec{
+		_, err = scope.Counter(Spec{
 			Name: "scrubbed&name",
 			Help: "help",
 		})
@@ -120,13 +120,13 @@ func TestScalarMetricDuplicates(t *testing.T) {
 
 	t.Run("duplicate scrubbed dimensions", func(t *testing.T) {
 		// Uniqueness is enforced after tags are scrubbed.
-		_, err := scope.NewCounter(Spec{
+		_, err := scope.Counter(Spec{
 			Name:      "scrubbed_dimensions",
 			Help:      "help",
 			ConstTags: Tags{"b_r": "baz"},
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = scope.NewCounter(Spec{
+		_, err = scope.Counter(Spec{
 			Name:      "scrubbed_dimensions",
 			Help:      "help",
 			ConstTags: Tags{"b&r": "baz"},
@@ -137,7 +137,7 @@ func TestScalarMetricDuplicates(t *testing.T) {
 	t.Run("constant tag name specified twice", func(t *testing.T) {
 		// Within a single user-supplied set of tags, scrubbing may not
 		// introduce duplicates.
-		_, err = scope.NewCounter(Spec{
+		_, err = scope.Counter(Spec{
 			Name:      "user_error_constant_tags",
 			Help:      "help",
 			ConstTags: Tags{"b_r": "baz", "b&r": "baz"},
@@ -153,20 +153,20 @@ func TestVectorMetricDuplicates(t *testing.T) {
 		Help:    "help",
 		VarTags: []string{"foo"},
 	}
-	_, err := scope.NewCounterVector(spec)
+	_, err := scope.CounterVector(spec)
 	assert.NoError(t, err, "Failed first registration.")
 
 	t.Run("same type", func(t *testing.T) {
 		// You can't reuse specs with the same metric type.
-		_, err := scope.NewCounterVector(spec)
+		_, err := scope.CounterVector(spec)
 		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
 	})
 
 	t.Run("different type", func(t *testing.T) {
 		// Even if you change the metric type, you still can't re-use metadata.
-		_, err := scope.NewGaugeVector(spec)
+		_, err := scope.GaugeVector(spec)
 		assert.Error(t, err, "Unexpected success re-using vector metrics metadata.")
-		_, err = scope.NewHistogramVector(HistogramSpec{
+		_, err = scope.HistogramVector(HistogramSpec{
 			Spec:    spec,
 			Unit:    time.Nanosecond,
 			Buckets: []int64{1, 2},
@@ -177,14 +177,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("different type and mixed tags", func(t *testing.T) {
 		// If we change the type and make some constant tags variable, we still
 		// can't re-use metadata.
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:      "test_different_type_mixed_tags",
 			Help:      "help",
 			ConstTags: Tags{"foo": "ok"},
 			VarTags:   []string{"bar"},
 		})
 		require.NoError(t, err, "Failed to create initial metric.")
-		_, err = scope.NewGaugeVector(Spec{
+		_, err = scope.GaugeVector(Spec{
 			Name:    "test_different_type_mixed_tags",
 			Help:    "help",
 			VarTags: []string{"foo", "bar"},
@@ -194,7 +194,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 
 	t.Run("different help", func(t *testing.T) {
 		// Changing the help string doesn't change the metric's identity.
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:    "foo",
 			Help:    "different help",
 			VarTags: []string{"foo"},
@@ -204,14 +204,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 
 	t.Run("added dimensions", func(t *testing.T) {
 		// Can't have the same metric name with added dimensions.
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:      "foo",
 			Help:      "help",
 			VarTags:   []string{"foo"},
 			ConstTags: Tags{"bar": "baz"},
 		})
 		assert.Error(t, err, "Shouldn't be able to add constant tags.")
-		_, err = scope.NewCounterVector(Spec{
+		_, err = scope.CounterVector(Spec{
 			Name:    "foo",
 			Help:    "help",
 			VarTags: []string{"foo", "bar"},
@@ -222,7 +222,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("different dimensions", func(t *testing.T) {
 		// Even if the number of dimensions is the same, metrics with the same
 		// name must have the same dimensions.
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:    "foo",
 			Help:    "help",
 			VarTags: []string{"bar"},
@@ -234,14 +234,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 		// If a metric has the same name and dimensions, the tag values
 		// may change. (Again, this would be more efficiently modeled as a
 		// higher-dimensionality vector.)
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:      "dimensions",
 			Help:      "help",
 			ConstTags: Tags{"bar": "baz"},
 			VarTags:   []string{"foo"},
 		})
 		assert.NoError(t, err)
-		_, err = scope.NewCounterVector(Spec{
+		_, err = scope.CounterVector(Spec{
 			Name:      "dimensions",
 			Help:      "help",
 			ConstTags: Tags{"bar": "quux"},
@@ -257,7 +257,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 		// carte scalars.
 
 		// dims: foo, baz
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:      "ownership",
 			Help:      "help",
 			ConstTags: Tags{"foo": "bar"},
@@ -266,7 +266,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 		require.NoError(t, err)
 
 		// same dims
-		_, err = scope.NewCounter(Spec{
+		_, err = scope.Counter(Spec{
 			Name:      "ownership",
 			Help:      "help",
 			ConstTags: Tags{"foo": "bar", "baz": "quux"},
@@ -276,13 +276,13 @@ func TestVectorMetricDuplicates(t *testing.T) {
 
 	t.Run("duplicate scrubbed name", func(t *testing.T) {
 		// Uniqueness is enforced after the metric name is scrubbed.
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:    "scrubbed_name",
 			Help:    "help",
 			VarTags: []string{"bar"},
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = scope.NewCounterVector(Spec{
+		_, err = scope.CounterVector(Spec{
 			Name:    "scrubbed&name",
 			Help:    "help",
 			VarTags: []string{"bar"},
@@ -292,14 +292,14 @@ func TestVectorMetricDuplicates(t *testing.T) {
 
 	t.Run("duplicate scrubbed dimensions", func(t *testing.T) {
 		// Uniqueness is enforced after tags are scrubbed.
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:      "scrubbed_dimensions",
 			Help:      "help",
 			ConstTags: Tags{"b_r": "baz"},
 			VarTags:   []string{"q__x"},
 		})
 		assert.NoError(t, err, "Failed to register new metric.")
-		_, err = scope.NewCounterVector(Spec{
+		_, err = scope.CounterVector(Spec{
 			Name:      "scrubbed_dimensions",
 			Help:      "help",
 			ConstTags: Tags{"b&r": "baz"},
@@ -311,7 +311,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("constant tag name specified twice", func(t *testing.T) {
 		// Within a single user-supplied set of constant tags, scrubbing may not
 		// introduce duplicates.
-		_, err = scope.NewCounterVector(Spec{
+		_, err = scope.CounterVector(Spec{
 			Name:      "user_error_constant_tags",
 			Help:      "help",
 			ConstTags: Tags{"b_r": "baz", "b&r": "baz"},
@@ -323,7 +323,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	t.Run("variable tag name specified twice", func(t *testing.T) {
 		// Within a single user-supplied set of variable tags, scrubbing may not
 		// introduce duplicates.
-		_, err = scope.NewCounterVector(Spec{
+		_, err = scope.CounterVector(Spec{
 			Name:    "user_error_variable_tags",
 			Help:    "help",
 			VarTags: []string{"f__", "f&&"},
@@ -332,7 +332,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 	})
 
 	t.Run("constant and variable tag name overlap", func(t *testing.T) {
-		_, err = scope.NewCounterVector(Spec{
+		_, err = scope.CounterVector(Spec{
 			Name:      "user_error_tag_overlaps",
 			Help:      "help",
 			ConstTags: Tags{"foo": "one"},
@@ -345,7 +345,7 @@ func TestVectorMetricDuplicates(t *testing.T) {
 func TestTaggedPrecedence(t *testing.T) {
 	root := New()
 	scope := root.Scope().Tagged(Tags{"foo": "bar"}).Tagged(Tags{"foo": "baz"})
-	_, err := scope.NewCounter(Spec{
+	_, err := scope.Counter(Spec{
 		Name: "test_counter",
 		Help: "help",
 	})
@@ -365,7 +365,7 @@ func TestTaggedAutoScrubbing(t *testing.T) {
 		"tally":                   "invalid!value",
 		"valid":                   "ok",
 	})
-	vec, err := scope.NewCounterVector(Spec{
+	vec, err := scope.CounterVector(Spec{
 		Name:    "test_counter",
 		Help:    "help",
 		VarTags: []string{"invalid_var_name!"},
@@ -390,7 +390,7 @@ func TestTaggedAutoScrubbing(t *testing.T) {
 func TestTagScrubbingUniqueness(t *testing.T) {
 	t.Run("duplicate const names", func(t *testing.T) {
 		scope := New().Scope()
-		_, err := scope.NewCounter(Spec{
+		_, err := scope.Counter(Spec{
 			Name: "test",
 			Help: "help",
 			ConstTags: Tags{
@@ -402,7 +402,7 @@ func TestTagScrubbingUniqueness(t *testing.T) {
 	})
 	t.Run("duplicate variable names", func(t *testing.T) {
 		scope := New().Scope()
-		_, err := scope.NewCounterVector(Spec{
+		_, err := scope.CounterVector(Spec{
 			Name:    "test",
 			Help:    "help",
 			VarTags: []string{"foo_bar", "foo!bar"},

--- a/snapshot.go
+++ b/snapshot.go
@@ -56,7 +56,7 @@ func (l HistogramSnapshot) less(other HistogramSnapshot) bool {
 }
 
 // A RootSnapshot exposes all the metrics contained in a Root and all its
-// Scopes. It's useful in tests, but shouldn't be used in production code.
+// Scopes. It's useful in tests, but relatively expensive to construct.
 type RootSnapshot struct {
 	Counters   []Snapshot
 	Gauges     []Snapshot

--- a/snapshot.go
+++ b/snapshot.go
@@ -25,23 +25,22 @@ import (
 	"time"
 )
 
-// A SimpleSnapshot is a point-in-time snapshot of the state of any
-// non-histogram metric.
-type SimpleSnapshot struct {
+// A Snapshot is a point-in-time view of the state of any non-histogram
+// metric.
+type Snapshot struct {
 	Name   string
 	Labels Labels
 	Value  int64
 }
 
-func (s SimpleSnapshot) less(other SimpleSnapshot) bool {
+func (s Snapshot) less(other Snapshot) bool {
 	if s.Name != other.Name {
 		return s.Name < other.Name
 	}
 	return s.Labels.less(other.Labels)
 }
 
-// A HistogramSnapshot is a point-in-time snapshot of the state of a
-// Histogram.
+// A HistogramSnapshot is a point-in-time view of the state of a Histogram.
 type HistogramSnapshot struct {
 	Name   string
 	Labels Labels
@@ -56,15 +55,15 @@ func (l HistogramSnapshot) less(other HistogramSnapshot) bool {
 	return l.Labels.less(other.Labels)
 }
 
-// A Snapshot exposes all the metrics contained in a Registry. It's useful in
-// tests, but shouldn't be used in production code.
-type Snapshot struct {
-	Counters   []SimpleSnapshot
-	Gauges     []SimpleSnapshot
+// A RegistrySnapshot exposes all the metrics contained in a Registry. It's
+// useful in tests, but shouldn't be used in production code.
+type RegistrySnapshot struct {
+	Counters   []Snapshot
+	Gauges     []Snapshot
 	Histograms []HistogramSnapshot
 }
 
-func (s *Snapshot) sort() {
+func (s *RegistrySnapshot) sort() {
 	sort.Slice(s.Counters, func(i, j int) bool {
 		return s.Counters[i].less(s.Counters[j])
 	})
@@ -76,7 +75,7 @@ func (s *Snapshot) sort() {
 	})
 }
 
-func (s *Snapshot) add(m metric) {
+func (s *RegistrySnapshot) add(m metric) {
 	switch v := m.(type) {
 	case *Counter:
 		s.Counters = append(s.Counters, v.snapshot())

--- a/snapshot.go
+++ b/snapshot.go
@@ -55,15 +55,15 @@ func (l HistogramSnapshot) less(other HistogramSnapshot) bool {
 	return l.Labels.less(other.Labels)
 }
 
-// A RegistrySnapshot exposes all the metrics contained in a Registry. It's
-// useful in tests, but shouldn't be used in production code.
-type RegistrySnapshot struct {
+// A RootSnapshot exposes all the metrics contained in a Root and all its
+// Scopes. It's useful in tests, but shouldn't be used in production code.
+type RootSnapshot struct {
 	Counters   []Snapshot
 	Gauges     []Snapshot
 	Histograms []HistogramSnapshot
 }
 
-func (s *RegistrySnapshot) sort() {
+func (s *RootSnapshot) sort() {
 	sort.Slice(s.Counters, func(i, j int) bool {
 		return s.Counters[i].less(s.Counters[j])
 	})
@@ -75,7 +75,7 @@ func (s *RegistrySnapshot) sort() {
 	})
 }
 
-func (s *RegistrySnapshot) add(m metric) {
+func (s *RootSnapshot) add(m metric) {
 	switch v := m.(type) {
 	case *Counter:
 		s.Counters = append(s.Counters, v.snapshot())

--- a/snapshot.go
+++ b/snapshot.go
@@ -28,22 +28,22 @@ import (
 // A Snapshot is a point-in-time view of the state of any non-histogram
 // metric.
 type Snapshot struct {
-	Name   string
-	Labels Labels
-	Value  int64
+	Name  string
+	Tags  Tags
+	Value int64
 }
 
 func (s Snapshot) less(other Snapshot) bool {
 	if s.Name != other.Name {
 		return s.Name < other.Name
 	}
-	return s.Labels.less(other.Labels)
+	return s.Tags.less(other.Tags)
 }
 
 // A HistogramSnapshot is a point-in-time view of the state of a Histogram.
 type HistogramSnapshot struct {
 	Name   string
-	Labels Labels
+	Tags   Tags
 	Unit   time.Duration
 	Values []int64 // rounded up to bucket upper bounds
 }
@@ -52,7 +52,7 @@ func (l HistogramSnapshot) less(other HistogramSnapshot) bool {
 	if l.Name != other.Name {
 		return l.Name < other.Name
 	}
-	return l.Labels.less(other.Labels)
+	return l.Tags.less(other.Tags)
 }
 
 // A RootSnapshot exposes all the metrics contained in a Root and all its

--- a/spec.go
+++ b/spec.go
@@ -71,7 +71,7 @@ type HistogramSpec struct {
 	Spec
 
 	// Durations are exposed as simple numbers, not strings or rich objects.
-	// Unit specifies the desired granularity for latency observations. For
+	// Unit specifies the desired granularity for histogram observations. For
 	// example, an observation of time.Second with a unit of time.Millisecond is
 	// exposed as 1000. Typically, the unit should also be part of the metric
 	// name.
@@ -82,20 +82,20 @@ type HistogramSpec struct {
 }
 
 func (hs HistogramSpec) validateScalar() error {
-	if err := hs.validateLatencies(); err != nil {
+	if err := hs.validateHistogram(); err != nil {
 		return err
 	}
 	return hs.Spec.validateScalar()
 }
 
 func (hs HistogramSpec) validateVector() error {
-	if err := hs.validateLatencies(); err != nil {
+	if err := hs.validateHistogram(); err != nil {
 		return err
 	}
 	return hs.Spec.validateVector()
 }
 
-func (hs HistogramSpec) validateLatencies() error {
+func (hs HistogramSpec) validateHistogram() error {
 	if hs.Unit < 1 {
 		return fmt.Errorf("duration unit must be positive, got %v", hs.Unit)
 	}

--- a/spec.go
+++ b/spec.go
@@ -70,12 +70,11 @@ func (s Spec) validateVector() error {
 type HistogramSpec struct {
 	Spec
 
-	// Durations are exported to Prometheus as simple numbers, not strings or
-	// rich objects. Unit specifies the desired granularity for latency
-	// observations. For example, an observation of time.Second with a unit of
-	// time.Millisecond is exported to Prometheus as 1000. Typically, the unit
-	// should also be part of the metric name; in this example, latency_ms is a
-	// good name.
+	// Durations are exposed as simple numbers, not strings or rich objects.
+	// Unit specifies the desired granularity for latency observations. For
+	// example, an observation of time.Second with a unit of time.Millisecond is
+	// exposed as 1000. Typically, the unit should also be part of the metric
+	// name.
 	Unit time.Duration
 	// Upper bounds (inclusive) for the histogram buckets. A catch-all bucket
 	// for large observations is automatically created, if necessary.

--- a/spec.go
+++ b/spec.go
@@ -29,11 +29,11 @@ import (
 
 // A Spec configures Counters, Gauges, CounterVectors, and GaugeVectors.
 type Spec struct {
-	Name           string
-	Help           string
-	Labels         Labels
-	VariableLabels []string // only meaningful for vectors
-	DisablePush    bool
+	Name        string   // required
+	Help        string   // required
+	ConstTags   Tags     // constant tags
+	VarTags     []string // variable tags, only meaningful for vectors
+	DisablePush bool
 }
 
 func (s Spec) validate() error {
@@ -50,8 +50,8 @@ func (s Spec) validateScalar() error {
 	if err := s.validate(); err != nil {
 		return err
 	}
-	if len(s.VariableLabels) > 0 {
-		return errors.New("only vectors may have variable labels")
+	if len(s.VarTags) > 0 {
+		return errors.New("only vectors may have variable tags")
 	}
 	return nil
 }
@@ -60,8 +60,8 @@ func (s Spec) validateVector() error {
 	if err := s.validate(); err != nil {
 		return err
 	}
-	if len(s.VariableLabels) == 0 {
-		return errors.New("vectors must have variable labels")
+	if len(s.VarTags) == 0 {
+		return errors.New("vectors must have variable tags")
 	}
 	return nil
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -356,7 +356,7 @@ func TestHistogramSpecValidation(t *testing.T) {
 			if tt.scalarOK {
 				assertScalarHistogramSpecOK(t, tt.spec)
 			} else {
-				assertSimpleHistogramSpecFail(t, tt.spec)
+				assertScalarHistogramSpecFail(t, tt.spec)
 			}
 			if tt.vecOK {
 				assertVectorHistogramSpecOK(t, tt.spec)
@@ -401,20 +401,20 @@ func assertVectorSpecFail(t testing.TB, spec Spec) {
 
 func assertScalarHistogramSpecOK(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().Histogram(spec)
-	assert.NoError(t, err, "Expected success from NewLatencies.")
+	assert.NoError(t, err, "Expected success from NewHistogram.")
 }
 
-func assertSimpleHistogramSpecFail(t testing.TB, spec HistogramSpec) {
+func assertScalarHistogramSpecFail(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().Histogram(spec)
-	assert.Error(t, err, "Expected an error from NewLatencies.")
+	assert.Error(t, err, "Expected an error from NewHistogram.")
 }
 
 func assertVectorHistogramSpecOK(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().HistogramVector(spec)
-	assert.NoError(t, err, "Expected success from NewLatenciesVector.")
+	assert.NoError(t, err, "Expected success from NewHistogramVector.")
 }
 
 func assertVectorHistogramSpecFail(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().HistogramVector(spec)
-	assert.Error(t, err, "Expected an error from NewLatenciesVector.")
+	assert.Error(t, err, "Expected an error from NewHistogramVector.")
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -44,11 +44,11 @@ func TestSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid names & constant labels",
+			desc: "valid names & constant tags",
 			spec: Spec{
-				Name:   "foo",
-				Help:   "Some help.",
-				Labels: Labels{"foo": "bar"},
+				Name:      "foo",
+				Help:      "Some help.",
+				ConstTags: Tags{"foo": "bar"},
 			},
 			scalarOK: true,
 			vecOK:    false,
@@ -79,53 +79,53 @@ func TestSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid names but invalid label key",
+			desc: "valid names but invalid tag key",
 			spec: Spec{
-				Name:   "foo",
-				Help:   "Some help.",
-				Labels: Labels{"foo:foo": "bar"},
+				Name:      "foo",
+				Help:      "Some help.",
+				ConstTags: Tags{"foo:foo": "bar"},
 			},
 			scalarOK: true,
 			vecOK:    false,
 		},
 		{
-			desc: "valid names but invalid label value",
+			desc: "valid names but invalid tag value",
 			spec: Spec{
-				Name:   "foo",
-				Help:   "Some help.",
-				Labels: Labels{"foo": "bar:bar"},
+				Name:      "foo",
+				Help:      "Some help.",
+				ConstTags: Tags{"foo": "bar:bar"},
 			},
 			scalarOK: true,
 			vecOK:    false,
 		},
 		{
-			desc: "valid names & variable labels",
+			desc: "valid names & variable tags",
 			spec: Spec{
-				Name:           "foo",
-				Help:           "Some help.",
-				VariableLabels: []string{"baz"},
+				Name:    "foo",
+				Help:    "Some help.",
+				VarTags: []string{"baz"},
 			},
 			scalarOK: false,
 			vecOK:    true,
 		},
 		{
-			desc: "valid names, constant labels, & variable labels",
+			desc: "valid names, constant tags, & variable tags",
 			spec: Spec{
-				Name:           "foo",
-				Help:           "Some help.",
-				Labels:         Labels{"foo": "bar"},
-				VariableLabels: []string{"baz"},
+				Name:      "foo",
+				Help:      "Some help.",
+				ConstTags: Tags{"foo": "bar"},
+				VarTags:   []string{"baz"},
 			},
 			scalarOK: false,
 			vecOK:    true,
 		},
 		{
-			desc: "valid names & constant labels, but invalid variable labels",
+			desc: "valid names & constant tags, but invalid variable tags",
 			spec: Spec{
-				Name:           "foo",
-				Help:           "Some help.",
-				Labels:         Labels{"foo": "bar"},
-				VariableLabels: []string{"baz:baz"},
+				Name:      "foo",
+				Help:      "Some help.",
+				ConstTags: Tags{"foo": "bar"},
+				VarTags:   []string{"baz:baz"},
 			},
 			scalarOK: false,
 			vecOK:    true,
@@ -169,12 +169,12 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid names & constant labels",
+			desc: "valid names & constant tags",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:   "foo",
-					Help:   "Some help.",
-					Labels: Labels{"foo": "bar"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar"},
 				},
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
@@ -220,12 +220,12 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid names but invalid label key",
+			desc: "valid names but invalid tag key",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:   "foo",
-					Help:   "Some help.",
-					Labels: Labels{"foo:foo": "bar"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo:foo": "bar"},
 				},
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
@@ -234,12 +234,12 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid names but invalid label value",
+			desc: "valid names but invalid tag value",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:   "foo",
-					Help:   "Some help.",
-					Labels: Labels{"foo": "bar:bar"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar:bar"},
 				},
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
@@ -248,12 +248,12 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid names & variable labels",
+			desc: "valid names & variable tags",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:           "foo",
-					Help:           "Some help.",
-					VariableLabels: []string{"baz"},
+					Name:    "foo",
+					Help:    "Some help.",
+					VarTags: []string{"baz"},
 				},
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
@@ -262,13 +262,13 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    true,
 		},
 		{
-			desc: "valid names, constant labels, & variable labels",
+			desc: "valid names, constant tags, & variable tags",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:           "foo",
-					Help:           "Some help.",
-					Labels:         Labels{"foo": "bar"},
-					VariableLabels: []string{"baz"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar"},
+					VarTags:   []string{"baz"},
 				},
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
@@ -277,13 +277,13 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    true,
 		},
 		{
-			desc: "valid names & constant labels, but invalid variable labels",
+			desc: "valid names & constant tags, but invalid variable tags",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:           "foo",
-					Help:           "Some help.",
-					Labels:         Labels{"foo": "bar"},
-					VariableLabels: []string{"baz:baz"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar"},
+					VarTags:   []string{"baz:baz"},
 				},
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
@@ -292,13 +292,13 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    true,
 		},
 		{
-			desc: "valid labels, no unit",
+			desc: "valid tags, no unit",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:           "foo",
-					Help:           "Some help.",
-					Labels:         Labels{"foo": "bar"},
-					VariableLabels: []string{"baz"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar"},
+					VarTags:   []string{"baz"},
 				},
 				Buckets: []int64{1000, 1000 * 60},
 			},
@@ -306,13 +306,13 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid labels, negative unit",
+			desc: "valid tags, negative unit",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:           "foo",
-					Help:           "Some help.",
-					Labels:         Labels{"foo": "bar"},
-					VariableLabels: []string{"baz"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar"},
+					VarTags:   []string{"baz"},
 				},
 				Unit:    -1 * time.Millisecond,
 				Buckets: []int64{1000, 1000 * 60},
@@ -321,13 +321,13 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid labels, no buckets",
+			desc: "valid tags, no buckets",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:           "foo",
-					Help:           "Some help.",
-					Labels:         Labels{"foo": "bar"},
-					VariableLabels: []string{"baz"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar"},
+					VarTags:   []string{"baz"},
 				},
 				Unit: time.Millisecond,
 			},
@@ -335,13 +335,13 @@ func TestHistogramSpecValidation(t *testing.T) {
 			vecOK:    false,
 		},
 		{
-			desc: "valid labels, buckets out of order",
+			desc: "valid tags, buckets out of order",
 			spec: HistogramSpec{
 				Spec: Spec{
-					Name:           "foo",
-					Help:           "Some help.",
-					Labels:         Labels{"foo": "bar"},
-					VariableLabels: []string{"baz"},
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar"},
+					VarTags:   []string{"baz"},
 				},
 				Unit:    time.Millisecond,
 				Buckets: []int64{1000 * 60, 1000},

--- a/spec_test.go
+++ b/spec_test.go
@@ -368,53 +368,53 @@ func TestHistogramSpecValidation(t *testing.T) {
 }
 
 func assertScalarSpecOK(t testing.TB, spec Spec) {
-	_, err := New().Scope().NewCounter(spec)
+	_, err := New().Scope().Counter(spec)
 	assert.NoError(t, err, "Expected success from NewCounter.")
 
-	_, err = New().Scope().NewGauge(spec)
+	_, err = New().Scope().Gauge(spec)
 	assert.NoError(t, err, "Expected success from NewGauge.")
 }
 
 func assertScalarSpecFail(t testing.TB, spec Spec) {
-	_, err := New().Scope().NewCounter(spec)
+	_, err := New().Scope().Counter(spec)
 	assert.Error(t, err, "Expected an error from NewCounter.")
 
-	_, err = New().Scope().NewGauge(spec)
+	_, err = New().Scope().Gauge(spec)
 	assert.Error(t, err, "Expected an error from NewGauge.")
 }
 
 func assertVectorSpecOK(t testing.TB, spec Spec) {
-	_, err := New().Scope().NewCounterVector(spec)
+	_, err := New().Scope().CounterVector(spec)
 	assert.NoError(t, err, "Expected success from NewCounterVector.")
 
-	_, err = New().Scope().NewGaugeVector(spec)
+	_, err = New().Scope().GaugeVector(spec)
 	assert.NoError(t, err, "Expected success from NewGaugeVector.")
 }
 
 func assertVectorSpecFail(t testing.TB, spec Spec) {
-	_, err := New().Scope().NewCounterVector(spec)
+	_, err := New().Scope().CounterVector(spec)
 	assert.Error(t, err, "Expected an error from NewCounterVector.")
 
-	_, err = New().Scope().NewGaugeVector(spec)
+	_, err = New().Scope().GaugeVector(spec)
 	assert.Error(t, err, "Expected an error from NewGaugeVector.")
 }
 
 func assertScalarHistogramSpecOK(t testing.TB, spec HistogramSpec) {
-	_, err := New().Scope().NewHistogram(spec)
+	_, err := New().Scope().Histogram(spec)
 	assert.NoError(t, err, "Expected success from NewLatencies.")
 }
 
 func assertSimpleHistogramSpecFail(t testing.TB, spec HistogramSpec) {
-	_, err := New().Scope().NewHistogram(spec)
+	_, err := New().Scope().Histogram(spec)
 	assert.Error(t, err, "Expected an error from NewLatencies.")
 }
 
 func assertVectorHistogramSpecOK(t testing.TB, spec HistogramSpec) {
-	_, err := New().Scope().NewHistogramVector(spec)
+	_, err := New().Scope().HistogramVector(spec)
 	assert.NoError(t, err, "Expected success from NewLatenciesVector.")
 }
 
 func assertVectorHistogramSpecFail(t testing.TB, spec HistogramSpec) {
-	_, err := New().Scope().NewHistogramVector(spec)
+	_, err := New().Scope().HistogramVector(spec)
 	assert.Error(t, err, "Expected an error from NewLatenciesVector.")
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -367,58 +367,54 @@ func TestHistogramSpecValidation(t *testing.T) {
 	}
 }
 
-func justRegistry(r *Registry, _ *Controller) *Registry {
-	return r
-}
-
 func assertScalarSpecOK(t testing.TB, spec Spec) {
-	_, err := justRegistry(New()).NewCounter(spec)
+	_, err := New().Scope().NewCounter(spec)
 	assert.NoError(t, err, "Expected success from NewCounter.")
 
-	_, err = justRegistry(New()).NewGauge(spec)
+	_, err = New().Scope().NewGauge(spec)
 	assert.NoError(t, err, "Expected success from NewGauge.")
 }
 
 func assertScalarSpecFail(t testing.TB, spec Spec) {
-	_, err := justRegistry(New()).NewCounter(spec)
+	_, err := New().Scope().NewCounter(spec)
 	assert.Error(t, err, "Expected an error from NewCounter.")
 
-	_, err = justRegistry(New()).NewGauge(spec)
+	_, err = New().Scope().NewGauge(spec)
 	assert.Error(t, err, "Expected an error from NewGauge.")
 }
 
 func assertVectorSpecOK(t testing.TB, spec Spec) {
-	_, err := justRegistry(New()).NewCounterVector(spec)
+	_, err := New().Scope().NewCounterVector(spec)
 	assert.NoError(t, err, "Expected success from NewCounterVector.")
 
-	_, err = justRegistry(New()).NewGaugeVector(spec)
+	_, err = New().Scope().NewGaugeVector(spec)
 	assert.NoError(t, err, "Expected success from NewGaugeVector.")
 }
 
 func assertVectorSpecFail(t testing.TB, spec Spec) {
-	_, err := justRegistry(New()).NewCounterVector(spec)
+	_, err := New().Scope().NewCounterVector(spec)
 	assert.Error(t, err, "Expected an error from NewCounterVector.")
 
-	_, err = justRegistry(New()).NewGaugeVector(spec)
+	_, err = New().Scope().NewGaugeVector(spec)
 	assert.Error(t, err, "Expected an error from NewGaugeVector.")
 }
 
 func assertScalarHistogramSpecOK(t testing.TB, spec HistogramSpec) {
-	_, err := justRegistry(New()).NewHistogram(spec)
+	_, err := New().Scope().NewHistogram(spec)
 	assert.NoError(t, err, "Expected success from NewLatencies.")
 }
 
 func assertSimpleHistogramSpecFail(t testing.TB, spec HistogramSpec) {
-	_, err := justRegistry(New()).NewHistogram(spec)
+	_, err := New().Scope().NewHistogram(spec)
 	assert.Error(t, err, "Expected an error from NewLatencies.")
 }
 
 func assertVectorHistogramSpecOK(t testing.TB, spec HistogramSpec) {
-	_, err := justRegistry(New()).NewHistogramVector(spec)
+	_, err := New().Scope().NewHistogramVector(spec)
 	assert.NoError(t, err, "Expected success from NewLatenciesVector.")
 }
 
 func assertVectorHistogramSpecFail(t testing.TB, spec HistogramSpec) {
-	_, err := justRegistry(New()).NewHistogramVector(spec)
+	_, err := New().Scope().NewHistogramVector(spec)
 	assert.Error(t, err, "Expected an error from NewLatenciesVector.")
 }

--- a/tag.go
+++ b/tag.go
@@ -28,11 +28,9 @@ import (
 	promproto "github.com/prometheus/client_model/go"
 )
 
+// Placeholders for empty tag names and values.
 const (
-	// DefaultTagName is used in place of empty tag names.
-	DefaultTagName = "default"
-
-	// DefaultTagValue is used in place of empty tag values.
+	DefaultTagName  = "default"
 	DefaultTagValue = "default"
 )
 
@@ -111,10 +109,10 @@ func (t Tags) addToDigester(d *digester) {
 // IsValidName checks whether the supplied string is a valid metric and tag
 // name in both Prometheus and Tally.
 //
-// Tally and Prometheus each allow runes that the other doesn't, so
-// net/metrics can accept only the common subset. For simplicity, we'd also
-// like the rules for metric names and tag names to be the same even if that's
-// more restrictive than absolutely necessary.
+// Tally and Prometheus each allow runes that the other doesn't, so this
+// package can accept only the common subset. For simplicity, we'd also like
+// the rules for metric names and tag names to be the same even if that's more
+// restrictive than absolutely necessary.
 //
 // Tally allows anything matching the regexp `^[0-9A-z_\-]+$`. Prometheus
 // allows the regexp `^[A-z_:][0-9A-z_:]*$` for metric names, and

--- a/tag_test.go
+++ b/tag_test.go
@@ -82,7 +82,7 @@ func TestIsValidName(t *testing.T) {
 	), "Hand-rolled validation doesn't match Tally regexp && stock Prometheus validators.")
 }
 
-func TestIsValidLabelValue(t *testing.T) {
+func TestIsValidTagValue(t *testing.T) {
 	tallyRe := regexp.MustCompile(`^[0-9A-z_.\-]+$`)
 	isValid := func(s string) bool {
 		prom := model.LabelValue(s).IsValid()
@@ -97,20 +97,20 @@ func TestIsValidLabelValue(t *testing.T) {
 	), "Hand-rolled validation doesn't match Tally regexp && stock Prometheus validators.")
 }
 
-func TestScrubLabelValue(t *testing.T) {
+func TestScrubTagValue(t *testing.T) {
 	tests := []struct {
 		in  string
 		out string
 	}{
 		{"foo", "foo"},
-		{"", DefaultLabelValue},
+		{"", DefaultTagValue},
 		{"foo!", "foo_"},
 		{"!foo", "_foo"},
 		{"fOo1.!FoO", "fOo1._FoO"},
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.out, scrubLabelValue(tt.in), "Unexpected result from scrubLabelValue.")
+		assert.Equal(t, tt.out, scrubTagValue(tt.in), "Unexpected result from scrubTagValue.")
 	}
 }
 
@@ -119,7 +119,7 @@ func TestScrubName(t *testing.T) {
 		in  string
 		out string
 	}{
-		{"", DefaultLabelValue},
+		{"", DefaultTagValue},
 		{"foo", "foo"},
 		{"foo!", "foo_"},
 		{"!foo", "_foo"},
@@ -145,13 +145,13 @@ func TestScrubQuick(t *testing.T) {
 			return IsValidName(scrubbed)
 		}, nil)
 	})
-	t.Run("scrubLabelValue", func(t *testing.T) {
+	t.Run("scrubTagValue", func(t *testing.T) {
 		quick.Check(func(s string) bool {
-			scrubbed := scrubLabelValue(s)
-			if IsValidLabelValue(s) {
+			scrubbed := scrubTagValue(s)
+			if IsValidTagValue(s) {
 				return s == scrubbed
 			}
-			return IsValidLabelValue(scrubbed)
+			return IsValidTagValue(scrubbed)
 		}, nil)
 	})
 }

--- a/tallypush/tally.go
+++ b/tallypush/tally.go
@@ -40,12 +40,12 @@ type target struct {
 
 func (tp *target) NewCounter(spec push.Spec) push.Counter {
 	return &counter{
-		Counter: tp.Tagged(spec.Labels).Counter(spec.Name),
+		Counter: tp.Tagged(spec.Tags).Counter(spec.Name),
 	}
 }
 
 func (tp *target) NewGauge(spec push.Spec) push.Gauge {
-	return &gauge{tp.Tagged(spec.Labels).Gauge(spec.Name)}
+	return &gauge{tp.Tagged(spec.Tags).Gauge(spec.Name)}
 }
 
 func (tp *target) NewHistogram(spec push.HistogramSpec) push.Histogram {
@@ -58,7 +58,7 @@ func (tp *target) NewHistogram(spec push.HistogramSpec) push.Histogram {
 		}
 	}
 	return &latency{
-		Histogram: tp.Tagged(spec.Labels).Histogram(
+		Histogram: tp.Tagged(spec.Tags).Histogram(
 			spec.Name,
 			tally.ValueBuckets(buckets),
 		),

--- a/tallypush/tally.go
+++ b/tallypush/tally.go
@@ -57,7 +57,7 @@ func (tp *target) NewHistogram(spec push.HistogramSpec) push.Histogram {
 			buckets[i] = float64(spec.Buckets[i])
 		}
 	}
-	return &latency{
+	return &histogram{
 		Histogram: tp.Tagged(spec.Tags).Histogram(
 			spec.Name,
 			tally.ValueBuckets(buckets),
@@ -86,7 +86,7 @@ func (tg *gauge) Set(value int64) {
 	tg.Update(float64(value))
 }
 
-type latency struct {
+type histogram struct {
 	tally.Histogram
 
 	// lasts keep the last value pushed to tally per histogram bucket.  This
@@ -94,11 +94,11 @@ type latency struct {
 	lasts map[int64]int64
 }
 
-func (tg *latency) Set(bucket int64, total int64) {
-	delta := total - tg.lasts[bucket]
-	tg.lasts[bucket] = total
+func (th *histogram) Set(bucket int64, total int64) {
+	delta := total - th.lasts[bucket]
+	th.lasts[bucket] = total
 
 	for i := int64(0); i < delta; i++ {
-		tg.RecordValue(float64(bucket))
+		th.RecordValue(float64(bucket))
 	}
 }

--- a/tallypush/tally_test.go
+++ b/tallypush/tally_test.go
@@ -40,8 +40,8 @@ func TestCounter(t *testing.T) {
 	scope := newScope()
 	target := New(scope)
 	c := target.NewCounter(push.Spec{
-		Name:   "test_counter",
-		Labels: metrics.Labels{"foo": "bar"},
+		Name: "test_counter",
+		Tags: metrics.Tags{"foo": "bar"},
 	})
 	c.Set(10)
 	c.Set(20) // should overwrite previous value
@@ -54,8 +54,8 @@ func TestGauge(t *testing.T) {
 	scope := newScope()
 	target := New(scope)
 	g := target.NewGauge(push.Spec{
-		Name:   "test_gauge",
-		Labels: metrics.Labels{"foo": "bar"},
+		Name: "test_gauge",
+		Tags: metrics.Tags{"foo": "bar"},
 	})
 	g.Set(10)
 	g.Set(20) // should overwrite previous value
@@ -68,7 +68,7 @@ func TestHistogram(t *testing.T) {
 	scope := newScope()
 	target := New(scope)
 	h := target.NewHistogram(push.HistogramSpec{
-		Spec:    push.Spec{Name: "test_histogram", Labels: metrics.Labels{"foo": "bar"}},
+		Spec:    push.Spec{Name: "test_histogram", Tags: metrics.Tags{"foo": "bar"}},
 		Buckets: []int64{5, 10, math.MaxInt64},
 	})
 	h.Set(5, 1)

--- a/value.go
+++ b/value.go
@@ -51,8 +51,8 @@ func newDynamicValue(m metadata, variableLabels []string) value {
 	}
 }
 
-func (v value) snapshot() SimpleSnapshot {
-	return SimpleSnapshot{
+func (v value) snapshot() Snapshot {
+	return Snapshot{
 		Name:   *v.meta.Name,
 		Labels: zip(v.labelPairs),
 		Value:  v.Load(),
@@ -106,10 +106,10 @@ func (vec *vector) newValue(key []byte, variableLabels []string) (metric, error)
 	return m, nil
 }
 
-func (vec *vector) snapshot() []SimpleSnapshot {
+func (vec *vector) snapshot() []Snapshot {
 	vec.metricsMu.RLock()
 	defer vec.metricsMu.RUnlock()
-	snaps := make([]SimpleSnapshot, 0, len(vec.metrics))
+	snaps := make([]Snapshot, 0, len(vec.metrics))
 	for _, m := range vec.metrics {
 		switch v := m.(type) {
 		case *Counter:

--- a/version.go
+++ b/version.go
@@ -20,5 +20,6 @@
 
 package metrics
 
-// Version is exported for runtime compatibility checks.
+// Version is the current semantic version, exported for runtime compatibility
+// checks.
 const Version = "0.1.0"


### PR DESCRIPTION
To reduce confusion and align more closely with Tally's terminology, rename a few types:

* Registry --> Scope
* Controller --> Root
* Label --> Tag
* Snapshot --> RootSnapshot, SimpleSnapshot --> Snapshot
* Scope.New{Counter,Gauge,etc} --> Scope.{Counter,Gauge,etc.}

Finally, simplify the top-level `New` function by attaching the top-level scope to the root. This lets `New` return just one object, which is a surprisingly large ergonomic improvement (especially in unit tests).