### PR TITLE
Add minimally viable documentation

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,8 @@ coverage:
                                #   option: "X%" a static target percentage to hit
         if_not_found: success  # if parent is not found report status as success, error, or failure
         if_ci_failed: error    # if ci fails report status as success, error, or failure
+
+    patch:
+      default:
+        enabled: yes
+        target: 70

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ go:
   - 1.8
   - 1.9
 go_import_path: go.uber.org/net/metrics
-env:
-  global:
-    - TEST_TIME_SCALE=10
 cache:
   directories:
     - vendor

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifdef SHOULD_LINT
 	@echo "Installing test dependencies for vet..."
 	@go test -i $(PKGS)
 	@echo "Checking vet..."
-	@go tool vet $(VET_RULES) $(LINT_FILES) 2>&1 | tee -a lint.log
+	@go vet $(VET_RULES) $(LINT_PKGS) 2>&1 | tee -a lint.log
 	@echo "Checking lint..."
 	@golint $(LINT_PKGS) 2>&1 | tee -a lint.log
 	@echo "Checking for unresolved FIXMEs..."

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package bucket provides utility functions for constructing and merging
+// histogram buckets. Buckets are meant to be used in the base metrics
+// package's HistogramSpec struct.
+package bucket // import "go.uber.org/net/metrics/bucket"
+
+import (
+	"errors"
+)
+
+// NewRPCLatency returns a hand-crafted set of buckets useful for tracking the
+// latency of RPCs (in milliseconds). Buckets range from 1 to 10000 (i.e.,
+// 1ms-10s), getting less granular as latency increases.
+func NewRPCLatency() []int64 {
+	return []int64{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+		12, 14, 16, 18, 20,
+		25, 30, 35, 40, 45, 50,
+		60, 70, 80, 90, 100,
+		120, 140, 160, 180, 200,
+		250, 300, 350, 400, 450, 500,
+		600, 700, 800, 900, 1000,
+		1500, 2000, 2500, 3000,
+		4000, 5000, 7500, 10000,
+	}
+}
+
+// NewExponential creates n exponential buckets, starting with the supplied
+// initial value and increasing by a user-defined factor each time.
+//
+// If n is less than one, the initial value is less than one, or the factor
+// is less than two, NewExponential returns a nil slice.
+func NewExponential(initial, factor int64, n int) []int64 {
+	if n < 1 || initial < 1 || factor < 2 {
+		return nil
+	}
+	buckets := make([]int64, n)
+	buckets[0] = initial
+	for i := 1; i < len(buckets); i++ {
+		buckets[i] = buckets[i-1] * factor
+	}
+	return buckets
+}
+
+// NewLinear creates n linear buckets, starting with the supplied
+// initial value and increasing by a user-defined width.
+//
+// If n or width are less than one, NewLinear returns a nil slice.
+func NewLinear(initial, width int64, n int) []int64 {
+	if n < 1 || width < 1 {
+		return nil
+	}
+	buckets := make([]int64, n)
+	buckets[0] = initial
+	for i := 1; i < len(buckets); i++ {
+		buckets[i] = buckets[i-1] + width
+	}
+	return buckets
+}
+
+// Flatten concatenates multiple sets of buckets into a single slice. After
+// flattening, it checks that the result is sorted and that no buckets are
+// duplicated.
+func Flatten(buckets ...[]int64) ([]int64, error) {
+	merged := flatten(buckets)
+	if asc := isAscending(merged); !asc {
+		return nil, errors.New("after flattening, buckets are not strictly ascending")
+	}
+	return merged, nil
+}
+
+func isAscending(ints []int64) bool {
+	// Don't use sort.IsSorted, since it permits duplicate elements.
+	if len(ints) < 2 {
+		return true
+	}
+	prev := ints[0]
+	for j := 1; j < len(ints); j++ {
+		if prev >= ints[j] {
+			return false
+		}
+		prev = ints[j]
+	}
+	return true
+}
+
+func flatten(iss [][]int64) []int64 {
+	var n int
+	for _, is := range iss {
+		n += len(is)
+	}
+	flat := make([]int64, 0, n)
+	for _, is := range iss {
+		flat = append(flat, is...)
+	}
+	return flat
+}

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bucket
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type int64s []int64
+
+func (is int64s) Len() int           { return len(is) }
+func (is int64s) Less(i, j int) bool { return is[i] < is[j] }
+func (is int64s) Swap(i, j int)      { is[i], is[j] = is[j], is[i] }
+
+func assertStrictlySorted(t testing.TB, is []int64) {
+	// We want the same result as the production code's isAscending without
+	// copying logic.
+	if !sort.IsSorted(int64s(is)) {
+		t.Logf("not sorted: %v", is)
+		t.Fail()
+	}
+	if hasDuplicates(is) {
+		t.Logf("has duplicate buckets: %v", is)
+		t.Fail()
+	}
+}
+
+func hasDuplicates(is []int64) bool {
+	set := make(map[int64]struct{}, len(is))
+	for _, i := range is {
+		if _, ok := set[i]; ok {
+			return true
+		}
+		set[i] = struct{}{}
+	}
+	return false
+}
+
+func TestNewRPC(t *testing.T) {
+	bs := NewRPCLatency()
+	require.True(t, len(bs) > 0, "Expected at least one bucket.")
+	assertStrictlySorted(t, bs)
+}
+
+func TestNewExponential(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs := NewExponential(1, 2, 3)
+		assert.Equal(t, []int64{1, 2, 4}, bs)
+	})
+	t.Run("too few buckets", func(t *testing.T) {
+		bs := NewExponential(1, 2, 0)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative start", func(t *testing.T) {
+		bs := NewExponential(-1, 2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero start", func(t *testing.T) {
+		bs := NewExponential(0, 2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative factor", func(t *testing.T) {
+		bs := NewExponential(1, -2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero factor", func(t *testing.T) {
+		bs := NewExponential(1, 0, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+}
+
+func TestNewLinear(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs := NewLinear(-2, 2, 4)
+		assert.Equal(t, []int64{-2, 0, 2, 4}, bs)
+	})
+	t.Run("too few buckets", func(t *testing.T) {
+		bs := NewLinear(2, 2, 0)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative width", func(t *testing.T) {
+		bs := NewLinear(-2, -1, 4)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero width", func(t *testing.T) {
+		bs := NewLinear(-2, 0, 4)
+		assert.Equal(t, 0, len(bs))
+	})
+}
+
+func TestFlatten(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs, err := Flatten([]int64{1, 2, 3}, []int64{5, 10, 15})
+		require.NoError(t, err, "Failed to flatten buckets.")
+		assert.Equal(t, []int64{1, 2, 3, 5, 10, 15}, bs)
+	})
+	t.Run("subslice not sorted", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 3, 2}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("subslice not uniqued", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 2}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("slices overlap", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 7}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("slices share bounds", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 5}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+}

--- a/core.go
+++ b/core.go
@@ -32,13 +32,8 @@ import (
 const _defaultCollectionSize = 128
 
 // A core is a collection of metrics. Uniqueness is enforced with two checks,
-// just like the vanilla Prometheus client:
-//
-// First, any two metrics with the same name must have the same tag names
-// (both constant and variable).
-//
-// Second, no two metrics can share the same name and the same constant tag
-// names and values.
+// explained in the documentation of the Root struct. The checks are slightly
+// stricter than those used by the official Prometheus client.
 //
 // The test suite for metric uniqueness is well-commented and explores the
 // consequences of these two rules.

--- a/counter.go
+++ b/counter.go
@@ -29,9 +29,8 @@ import (
 )
 
 // A Counter is a monotonically increasing value, like a car's odometer. All
-// its exported methods are safe to use concurrently.
-//
-// Nil *Counters are safe no-op implementations.
+// its exported methods are safe to use concurrently, and nil *Counters are
+// safe no-op implementations.
 type Counter struct {
 	val    value
 	pusher push.Counter
@@ -114,9 +113,8 @@ func (c *Counter) push(target push.Target) {
 
 // A CounterVector is a collection of Counters that share a name and some
 // constant tags, but also have a consistent set of variable tags. All
-// exported methods are safe to use concurrently.
-//
-// A nil *CounterVector is safe to use, and always returns no-op counters.
+// exported methods are safe to use concurrently. Nil *CounterVectors are safe
+// to use and always return no-op counters.
 //
 // For a general description of vector types, see the package-level
 // documentation.

--- a/doc.go
+++ b/doc.go
@@ -18,4 +18,62 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+// Package metrics is a telemetry client designed for Uber's software
+// networking team. It prioritizes performance on the hot path and integration
+// with both push- and pull-based collection systems. Like Prometheus and
+// Tally, it supports metrics tagged with arbitrary key-value pairs.
+//
+// Metric Names and Uniqueness
+//
+// Like Prometheus, but unlike Tally, metric names must be relatively long and
+// descriptive - generally speaking, metrics from the same process shouldn't
+// share names. (See the documentation for the Root struct below for a longer
+// explanation of the uniqueness rules.) For example, prefer
+// "grpc_successes_by_procedure" over "successes", since "successes" is common
+// and vague. Where relevant, metric names should indicate their unit of
+// measurement (e.g., "grpc_success_latency_ms").
+//
+// Counters and Gauges
+//
+// Counters represent monotonically increasing values, like a car's odometer.
+// Gauges represent point-in-time readings, like a car's speedometer. Both
+// counters and gauges expose not only write operations (set, add, increment,
+// etc.), but also atomic reads. This makes them easy to integrate directly
+// into your business logic: you can use them anywhere you'd otherwise use a
+// 64-bit atomic integer.
+//
+// Histograms
+//
+// This package doesn't support analogs of Tally's timer or Prometheus's
+// summary, because they can't be accurately aggregated at query time.
+// Instead, it approximates distributions of values with histograms. These
+// require more up-front work to set up, but are typically more accurate and
+// flexible when queried. See https://prometheus.io/docs/practices/histograms/
+// for a more detailed discussion of the trade-offs involved.
+//
+// Vectors
+//
+// Plain counters, gauges, and histograms have a fixed set of tags. However,
+// it's common to encounter situations where a subset of a metric's tags vary
+// constantly. For example, you might want to track the latency of your
+// database queries by table: you know the database cluster, application name,
+// and hostname at process startup, but you need to specify the table name
+// with each query. To model these situations, this package uses vectors.
+//
+// Each vector is a local cache of metrics, so accessing them is quite fast.
+// Within a vector, all metrics share a common set of constant tags and a list
+// of variable tags. In our database query example, the constant tags are
+// cluster, application, and hostname, and the only variable tag is table
+// name. Usage examples are included in the documentation for each vector
+// type.
+//
+// Push and Pull
+//
+// This package integrates with StatsD- and M3-based collection systems by
+// periodically pushing differential updates. (Users can integrate with other
+// push-based systems by implementing the push.Target interface.) It
+// integrates with pull-based collectors by exposing an HTTP handler that
+// supports Prometheus's text and protocol buffer exposition formats. Examples
+// of both push and pull integration are included in the documentation for the
+// root struct's Push and ServeHTTP methods.
 package metrics // import "go.uber.org/net/metrics"

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"time"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/net/metrics"
+	"go.uber.org/net/metrics/tallypush"
+)
+
+func Example() {
+	root := metrics.New()
+	scope := root.Scope().Tagged(metrics.Tags{
+		"host":   "db01",
+		"region": "us-west",
+	})
+
+	total, err := scope.Counter(metrics.Spec{
+		Name: "selects_completed",
+		Help: "Total number of completed SELECT queries.",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	progress, err := scope.GaugeVector(metrics.Spec{
+		Name:    "selects_in_progress",
+		Help:    "Number of in-progress SELECT queries.",
+		VarTags: []string{"table"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	trips := progress.MustGet("table" /* tag name */, "trips" /* tag value */)
+	drivers := progress.MustGet("table", "drivers")
+
+	fmt.Println("Trips:", trips.Inc())
+	total.Inc()
+	fmt.Println("Drivers:", drivers.Add(2))
+	total.Add(2)
+	fmt.Println("Drivers:", drivers.Dec())
+	fmt.Println("Trips:", trips.Dec())
+	fmt.Println("Total:", total.Load())
+
+	// Output:
+	// Trips: 1
+	// Drivers: 2
+	// Drivers: 1
+	// Trips: 0
+	// Total: 3
+}
+
+func ExampleCounter() {
+	c, err := metrics.New().Scope().Counter(metrics.Spec{
+		Name:      "selects_completed",                         // required
+		Help:      "Total number of completed SELECT queries.", // required
+		ConstTags: metrics.Tags{"host": "db01"},                // optional
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Add(2)
+}
+
+func ExampleCounterVector() {
+	vec, err := metrics.New().Scope().CounterVector(metrics.Spec{
+		Name:      "selects_completed_by_table",                   // required
+		Help:      "Number of completed SELECT queries by table.", // required
+		ConstTags: metrics.Tags{"host": "db01"},                   // optional
+		VarTags:   []string{"table"},                              // required
+	})
+	if err != nil {
+		panic(err)
+	}
+	vec.MustGet("table" /* tag name */, "trips" /* tag value */).Inc()
+}
+
+func ExampleGauge() {
+	g, err := metrics.New().Scope().Gauge(metrics.Spec{
+		Name:      "selects_in_progress",                       // required
+		Help:      "Total number of in-flight SELECT queries.", // required
+		ConstTags: metrics.Tags{"host": "db01"},                // optional
+	})
+	if err != nil {
+		panic(err)
+	}
+	g.Store(11)
+}
+
+func ExampleGaugeVector() {
+	vec, err := metrics.New().Scope().GaugeVector(metrics.Spec{
+		Name:      "selects_in_progress_by_table",                 // required
+		Help:      "Number of in-flight SELECT queries by table.", // required
+		ConstTags: metrics.Tags{"host": "db01"},                   // optional
+		VarTags:   []string{"table"},                              // optional
+	})
+	if err != nil {
+		panic(err)
+	}
+	vec.MustGet("table" /* tag name */, "trips" /* tag value */).Store(11)
+}
+
+func ExampleHistogram() {
+	h, err := metrics.New().Scope().Histogram(metrics.HistogramSpec{
+		Spec: metrics.Spec{
+			Name:      "selects_latency_ms",         // required, should indicate unit
+			Help:      "SELECT query latency.",      // required
+			ConstTags: metrics.Tags{"host": "db01"}, // optional
+		},
+		Unit:    time.Millisecond,                      // required
+		Buckets: []int64{5, 10, 25, 50, 100, 200, 500}, // required
+	})
+	if err != nil {
+		panic(err)
+	}
+	h.Observe(37 * time.Millisecond)
+}
+
+func ExampleHistogramVector() {
+	vec, err := metrics.New().Scope().HistogramVector(metrics.HistogramSpec{
+		Spec: metrics.Spec{
+			Name:      "selects_latency_by_table_ms",    // required, should indicate unit
+			Help:      "SELECT query latency by table.", // required
+			ConstTags: metrics.Tags{"host": "db01"},     // optional
+			VarTags:   []string{"table"},
+		},
+		Unit:    time.Millisecond,                      // required
+		Buckets: []int64{5, 10, 25, 50, 100, 200, 500}, // required
+	})
+	if err != nil {
+		panic(err)
+	}
+	vec.MustGet("table" /* tag name */, "trips" /* tag value */).Observe(37 * time.Millisecond)
+}
+
+func ExampleRoot_ServeHTTP() {
+	// First, construct a root and add some metrics.
+	root := metrics.New()
+	c, err := root.Scope().Counter(metrics.Spec{
+		Name:      "example",
+		Help:      "Counter demonstrating HTTP exposition.",
+		ConstTags: metrics.Tags{"host": "example01"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Inc()
+
+	// Expose the root on your HTTP server of choice.
+	mux := http.NewServeMux()
+	mux.Handle("/debug/net/metrics", root)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Your metrics are now exposed via a Prometheus-compatible handler. This
+	// example shows text output, but clients can also request the protocol
+	// buffer binary format.
+	res, err := http.Get(fmt.Sprintf("%v/debug/net/metrics", srv.URL))
+	if err != nil {
+		panic(err)
+	}
+	text, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(text))
+
+	// Output:
+	// # HELP example Counter demonstrating HTTP exposition.
+	// # TYPE example counter
+	// example{host="example01"} 1
+}
+
+func ExampleRoot_Push() {
+	// First, we need something to push to. In this example, we'll use Tally's
+	// testing scope.
+	ts := tally.NewTestScope("" /* prefix */, nil /* tags */)
+	root := metrics.New()
+
+	// Push updates to our test scope twice per second.
+	stop, err := root.Push(tallypush.New(ts), 500*time.Millisecond)
+	if err != nil {
+		panic(err)
+	}
+	defer stop()
+
+	c, err := root.Scope().Counter(metrics.Spec{
+		Name: "example",
+		Help: "Counter demonstrating push integration.",
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Inc()
+
+	// Sleep to make sure that we run at least one push, then print the counter
+	// value as seen by Tally.
+	time.Sleep(2 * time.Second)
+	fmt.Println(ts.Snapshot().Counters()["example+"].Value())
+
+	// Output:
+	// 1
+}
+
+func ExampleRoot_Snapshot() {
+	// Snapshots are the simplest way to unit test your metrics. A future
+	// release will add a more full-featured metricstest package.
+	root := metrics.New()
+	c, err := root.Scope().Counter(metrics.Spec{
+		Name:      "example",
+		Help:      "Counter demonstrating snapshots.",
+		ConstTags: metrics.Tags{"foo": "bar"},
+	})
+	if err != nil {
+		panic(err)
+	}
+	c.Inc()
+
+	// It's safe to snapshot your metrics in production, but keep in mind that
+	// taking a snapshot is relatively slow and expensive.
+	actual := root.Snapshot().Counters[0]
+	expected := metrics.Snapshot{
+		Name:  "example",
+		Value: 1,
+		Tags:  metrics.Tags{"foo": "bar"},
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		panic(fmt.Sprintf("expected %v, got %v", expected, actual))
+	}
+}

--- a/gauge.go
+++ b/gauge.go
@@ -29,9 +29,8 @@ import (
 )
 
 // A Gauge is a point-in-time measurement, like a car's speedometer. All its
-// exported methods are safe to use concurrently.
-//
-// Nil *Gauges are safe no-op implementations.
+// exported methods are safe to use concurrently, and nil *Gauges are safe
+// no-op implementations.
 type Gauge struct {
 	val    value
 	pusher push.Gauge
@@ -81,9 +80,10 @@ func (g *Gauge) Swap(n int64) int64 {
 	return g.val.Swap(n)
 }
 
-// CAS is a compare-and-swap. It compares the current value to the old value
-// supplied, and if they match it stores the new value. The return value
-// indicates whether the swap succeeded.
+// CAS is an atomic compare-and-swap. It compares the current value to the old
+// value supplied, and if they match it stores the new value. The return value
+// indicates whether the swap succeeded. To avoid endless CAS loops, no-op
+// gauges always return true.
 func (g *Gauge) CAS(old, new int64) bool {
 	if g == nil {
 		return true
@@ -91,7 +91,7 @@ func (g *Gauge) CAS(old, new int64) bool {
 	return g.val.CAS(old, new)
 }
 
-// Store changes the gauge's value.
+// Store sets the gauge's value.
 func (g *Gauge) Store(n int64) {
 	if g != nil {
 		g.val.Store(n)
@@ -146,9 +146,8 @@ func (g *Gauge) push(target push.Target) {
 
 // A GaugeVector is a collection of Gauges that share a name and some constant
 // tags, but also have a consistent set of variable tags. All exported methods
-// are safe to use concurrently.
-//
-// A nil *GaugeVector is safe to use, and always returns no-op gauges.
+// are safe to use concurrently. Nil *GaugeVectors are safe to use and always
+// return no-op gauges.
 //
 // For a general description of vector types, see the package-level
 // documentation.

--- a/histogram.go
+++ b/histogram.go
@@ -94,7 +94,8 @@ func newHistogram(m metadata, unit time.Duration, uppers []int64) *Histogram {
 }
 
 // Observe finds the correct bucket for the supplied duration and increments
-// its counter.
+// its counter. This is purely a convenience - it's equivalent to dividing the
+// duration by the histogram's unit and calling ObserveInt directly.
 func (h *Histogram) Observe(d time.Duration) {
 	if h == nil {
 		return
@@ -193,9 +194,8 @@ func (h *Histogram) push(target push.Target) {
 
 // A HistogramVector is a collection of Histograms that share a name and some
 // constant tags, but also have a consistent set of variable tags. All
-// exported methods are safe to use concurrently.
-//
-// A nil *HistogramVector is safe to use, and always returns no-op histograms.
+// exported methods are safe to use concurrently. Nil *HistogramVectors are
+// safe to use and always return no-op histograms.
 //
 // For a general description of vector types, see the package-level
 // documentation.

--- a/scope.go
+++ b/scope.go
@@ -33,9 +33,9 @@ func newScope(c *core, tags Tags) *Scope {
 	}
 }
 
-// Tagged creates a new Registry with new constant tags appended to the
-// current Registry's existing tags. Tag names and values are automatically
-// scrubbed, with invalid characters replaced by underscores.
+// Tagged creates a new scope with new constant tags merged into the existing
+// tags (if any). Tag names and values are automatically scrubbed, with
+// invalid characters replaced by underscores.
 func (s *Scope) Tagged(tags Tags) *Scope {
 	if s == nil {
 		return nil

--- a/snapshot.go
+++ b/snapshot.go
@@ -56,7 +56,7 @@ func (l HistogramSnapshot) less(other HistogramSnapshot) bool {
 }
 
 // A RootSnapshot exposes all the metrics contained in a Root and all its
-// Scopes. It's useful in tests, but shouldn't be used in production code.
+// Scopes. It's useful in tests, but relatively expensive to construct.
 type RootSnapshot struct {
 	Counters   []Snapshot
 	Gauges     []Snapshot

--- a/spec.go
+++ b/spec.go
@@ -71,7 +71,7 @@ type HistogramSpec struct {
 	Spec
 
 	// Durations are exposed as simple numbers, not strings or rich objects.
-	// Unit specifies the desired granularity for latency observations. For
+	// Unit specifies the desired granularity for histogram observations. For
 	// example, an observation of time.Second with a unit of time.Millisecond is
 	// exposed as 1000. Typically, the unit should also be part of the metric
 	// name.
@@ -82,20 +82,20 @@ type HistogramSpec struct {
 }
 
 func (hs HistogramSpec) validateScalar() error {
-	if err := hs.validateLatencies(); err != nil {
+	if err := hs.validateHistogram(); err != nil {
 		return err
 	}
 	return hs.Spec.validateScalar()
 }
 
 func (hs HistogramSpec) validateVector() error {
-	if err := hs.validateLatencies(); err != nil {
+	if err := hs.validateHistogram(); err != nil {
 		return err
 	}
 	return hs.Spec.validateVector()
 }
 
-func (hs HistogramSpec) validateLatencies() error {
+func (hs HistogramSpec) validateHistogram() error {
 	if hs.Unit < 1 {
 		return fmt.Errorf("duration unit must be positive, got %v", hs.Unit)
 	}

--- a/spec.go
+++ b/spec.go
@@ -70,12 +70,11 @@ func (s Spec) validateVector() error {
 type HistogramSpec struct {
 	Spec
 
-	// Durations are exported to Prometheus as simple numbers, not strings or
-	// rich objects. Unit specifies the desired granularity for latency
-	// observations. For example, an observation of time.Second with a unit of
-	// time.Millisecond is exported to Prometheus as 1000. Typically, the unit
-	// should also be part of the metric name; in this example, latency_ms is a
-	// good name.
+	// Durations are exposed as simple numbers, not strings or rich objects.
+	// Unit specifies the desired granularity for latency observations. For
+	// example, an observation of time.Second with a unit of time.Millisecond is
+	// exposed as 1000. Typically, the unit should also be part of the metric
+	// name.
 	Unit time.Duration
 	// Upper bounds (inclusive) for the histogram buckets. A catch-all bucket
 	// for large observations is automatically created, if necessary.

--- a/spec_test.go
+++ b/spec_test.go
@@ -356,7 +356,7 @@ func TestHistogramSpecValidation(t *testing.T) {
 			if tt.scalarOK {
 				assertScalarHistogramSpecOK(t, tt.spec)
 			} else {
-				assertSimpleHistogramSpecFail(t, tt.spec)
+				assertScalarHistogramSpecFail(t, tt.spec)
 			}
 			if tt.vecOK {
 				assertVectorHistogramSpecOK(t, tt.spec)
@@ -401,20 +401,20 @@ func assertVectorSpecFail(t testing.TB, spec Spec) {
 
 func assertScalarHistogramSpecOK(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().Histogram(spec)
-	assert.NoError(t, err, "Expected success from NewLatencies.")
+	assert.NoError(t, err, "Expected success from NewHistogram.")
 }
 
-func assertSimpleHistogramSpecFail(t testing.TB, spec HistogramSpec) {
+func assertScalarHistogramSpecFail(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().Histogram(spec)
-	assert.Error(t, err, "Expected an error from NewLatencies.")
+	assert.Error(t, err, "Expected an error from NewHistogram.")
 }
 
 func assertVectorHistogramSpecOK(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().HistogramVector(spec)
-	assert.NoError(t, err, "Expected success from NewLatenciesVector.")
+	assert.NoError(t, err, "Expected success from NewHistogramVector.")
 }
 
 func assertVectorHistogramSpecFail(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().HistogramVector(spec)
-	assert.Error(t, err, "Expected an error from NewLatenciesVector.")
+	assert.Error(t, err, "Expected an error from NewHistogramVector.")
 }

--- a/tag.go
+++ b/tag.go
@@ -28,11 +28,9 @@ import (
 	promproto "github.com/prometheus/client_model/go"
 )
 
+// Placeholders for empty tag names and values.
 const (
-	// DefaultTagName is used in place of empty tag names.
-	DefaultTagName = "default"
-
-	// DefaultTagValue is used in place of empty tag values.
+	DefaultTagName  = "default"
 	DefaultTagValue = "default"
 )
 
@@ -111,10 +109,10 @@ func (t Tags) addToDigester(d *digester) {
 // IsValidName checks whether the supplied string is a valid metric and tag
 // name in both Prometheus and Tally.
 //
-// Tally and Prometheus each allow runes that the other doesn't, so
-// net/metrics can accept only the common subset. For simplicity, we'd also
-// like the rules for metric names and tag names to be the same even if that's
-// more restrictive than absolutely necessary.
+// Tally and Prometheus each allow runes that the other doesn't, so this
+// package can accept only the common subset. For simplicity, we'd also like
+// the rules for metric names and tag names to be the same even if that's more
+// restrictive than absolutely necessary.
 //
 // Tally allows anything matching the regexp `^[0-9A-z_\-]+$`. Prometheus
 // allows the regexp `^[A-z_:][0-9A-z_:]*$` for metric names, and

--- a/tallypush/tally.go
+++ b/tallypush/tally.go
@@ -57,7 +57,7 @@ func (tp *target) NewHistogram(spec push.HistogramSpec) push.Histogram {
 			buckets[i] = float64(spec.Buckets[i])
 		}
 	}
-	return &latency{
+	return &histogram{
 		Histogram: tp.Tagged(spec.Tags).Histogram(
 			spec.Name,
 			tally.ValueBuckets(buckets),
@@ -86,7 +86,7 @@ func (tg *gauge) Set(value int64) {
 	tg.Update(float64(value))
 }
 
-type latency struct {
+type histogram struct {
 	tally.Histogram
 
 	// lasts keep the last value pushed to tally per histogram bucket.  This
@@ -94,11 +94,11 @@ type latency struct {
 	lasts map[int64]int64
 }
 
-func (tg *latency) Set(bucket int64, total int64) {
-	delta := total - tg.lasts[bucket]
-	tg.lasts[bucket] = total
+func (th *histogram) Set(bucket int64, total int64) {
+	delta := total - th.lasts[bucket]
+	th.lasts[bucket] = total
 
 	for i := int64(0); i < delta; i++ {
-		tg.RecordValue(float64(bucket))
+		th.RecordValue(float64(bucket))
 	}
 }

--- a/version.go
+++ b/version.go
@@ -20,5 +20,6 @@
 
 package metrics
 
-// Version is exported for runtime compatibility checks.
+// Version is the current semantic version, exported for runtime compatibility
+// checks.
 const Version = "0.1.0"


### PR DESCRIPTION
Add a package-level comment, a top-level example, and a number of type-specific examples, and then clean up some of the type- and method-level docs.