### PR TITLE
Add a subpackage for bucket utility functions

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,8 @@ coverage:
                                #   option: "X%" a static target percentage to hit
         if_not_found: success  # if parent is not found report status as success, error, or failure
         if_ci_failed: error    # if ci fails report status as success, error, or failure
+
+    patch:
+      default:
+        enabled: yes
+        target: 70

--- a/bucket/bucket.go
+++ b/bucket/bucket.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package bucket provides utility functions for constructing and merging
+// histogram buckets. Buckets are meant to be used in the base metrics
+// package's HistogramSpec struct.
+package bucket // import "go.uber.org/net/metrics/bucket"
+
+import (
+	"errors"
+)
+
+// NewRPCLatency returns a hand-crafted set of buckets useful for tracking the
+// latency of RPCs (in milliseconds). Buckets range from 1 to 10000 (i.e.,
+// 1ms-10s), getting less granular as latency increases.
+func NewRPCLatency() []int64 {
+	return []int64{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+		12, 14, 16, 18, 20,
+		25, 30, 35, 40, 45, 50,
+		60, 70, 80, 90, 100,
+		120, 140, 160, 180, 200,
+		250, 300, 350, 400, 450, 500,
+		600, 700, 800, 900, 1000,
+		1500, 2000, 2500, 3000,
+		4000, 5000, 7500, 10000,
+	}
+}
+
+// NewExponential creates n exponential buckets, starting with the supplied
+// initial value and increasing by a user-defined factor each time.
+//
+// If n is less than one, the initial value is less than one, or the factor
+// is less than two, NewExponential returns a nil slice.
+func NewExponential(initial, factor int64, n int) []int64 {
+	if n < 1 || initial < 1 || factor < 2 {
+		return nil
+	}
+	buckets := make([]int64, n)
+	buckets[0] = initial
+	for i := 1; i < len(buckets); i++ {
+		buckets[i] = buckets[i-1] * factor
+	}
+	return buckets
+}
+
+// NewLinear creates n linear buckets, starting with the supplied
+// initial value and increasing by a user-defined width.
+//
+// If n or width are less than one, NewLinear returns a nil slice.
+func NewLinear(initial, width int64, n int) []int64 {
+	if n < 1 || width < 1 {
+		return nil
+	}
+	buckets := make([]int64, n)
+	buckets[0] = initial
+	for i := 1; i < len(buckets); i++ {
+		buckets[i] = buckets[i-1] + width
+	}
+	return buckets
+}
+
+// Flatten concatenates multiple sets of buckets into a single slice. After
+// flattening, it checks that the result is sorted and that no buckets are
+// duplicated.
+func Flatten(buckets ...[]int64) ([]int64, error) {
+	merged := flatten(buckets)
+	if asc := isAscending(merged); !asc {
+		return nil, errors.New("after flattening, buckets are not strictly ascending")
+	}
+	return merged, nil
+}
+
+func isAscending(ints []int64) bool {
+	// Don't use sort.IsSorted, since it permits duplicate elements.
+	if len(ints) < 2 {
+		return true
+	}
+	prev := ints[0]
+	for j := 1; j < len(ints); j++ {
+		if prev >= ints[j] {
+			return false
+		}
+		prev = ints[j]
+	}
+	return true
+}
+
+func flatten(iss [][]int64) []int64 {
+	var n int
+	for _, is := range iss {
+		n += len(is)
+	}
+	flat := make([]int64, 0, n)
+	for _, is := range iss {
+		flat = append(flat, is...)
+	}
+	return flat
+}

--- a/bucket/bucket_test.go
+++ b/bucket/bucket_test.go
@@ -1,0 +1,135 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package bucket
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type int64s []int64
+
+func (is int64s) Len() int           { return len(is) }
+func (is int64s) Less(i, j int) bool { return is[i] < is[j] }
+func (is int64s) Swap(i, j int)      { is[i], is[j] = is[j], is[i] }
+
+func assertStrictlySorted(t testing.TB, is []int64) {
+	// We want the same result as the production code's isAscending without
+	// copying logic.
+	if !sort.IsSorted(int64s(is)) {
+		t.Logf("not sorted: %v", is)
+		t.Fail()
+	}
+	if hasDuplicates(is) {
+		t.Logf("has duplicate buckets: %v", is)
+		t.Fail()
+	}
+}
+
+func hasDuplicates(is []int64) bool {
+	set := make(map[int64]struct{}, len(is))
+	for _, i := range is {
+		if _, ok := set[i]; ok {
+			return true
+		}
+		set[i] = struct{}{}
+	}
+	return false
+}
+
+func TestNewRPC(t *testing.T) {
+	bs := NewRPCLatency()
+	require.True(t, len(bs) > 0, "Expected at least one bucket.")
+	assertStrictlySorted(t, bs)
+}
+
+func TestNewExponential(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs := NewExponential(1, 2, 3)
+		assert.Equal(t, []int64{1, 2, 4}, bs)
+	})
+	t.Run("too few buckets", func(t *testing.T) {
+		bs := NewExponential(1, 2, 0)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative start", func(t *testing.T) {
+		bs := NewExponential(-1, 2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero start", func(t *testing.T) {
+		bs := NewExponential(0, 2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative factor", func(t *testing.T) {
+		bs := NewExponential(1, -2, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero factor", func(t *testing.T) {
+		bs := NewExponential(1, 0, 3)
+		assert.Equal(t, 0, len(bs))
+	})
+}
+
+func TestNewLinear(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs := NewLinear(-2, 2, 4)
+		assert.Equal(t, []int64{-2, 0, 2, 4}, bs)
+	})
+	t.Run("too few buckets", func(t *testing.T) {
+		bs := NewLinear(2, 2, 0)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("negative width", func(t *testing.T) {
+		bs := NewLinear(-2, -1, 4)
+		assert.Equal(t, 0, len(bs))
+	})
+	t.Run("zero width", func(t *testing.T) {
+		bs := NewLinear(-2, 0, 4)
+		assert.Equal(t, 0, len(bs))
+	})
+}
+
+func TestFlatten(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		bs, err := Flatten([]int64{1, 2, 3}, []int64{5, 10, 15})
+		require.NoError(t, err, "Failed to flatten buckets.")
+		assert.Equal(t, []int64{1, 2, 3, 5, 10, 15}, bs)
+	})
+	t.Run("subslice not sorted", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 3, 2}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("subslice not uniqued", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 2}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("slices overlap", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 7}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+	t.Run("slices share bounds", func(t *testing.T) {
+		_, err := Flatten([]int64{1, 2, 5}, []int64{5, 10, 15})
+		require.Error(t, err)
+	})
+}

--- a/spec.go
+++ b/spec.go
@@ -71,7 +71,7 @@ type HistogramSpec struct {
 	Spec
 
 	// Durations are exposed as simple numbers, not strings or rich objects.
-	// Unit specifies the desired granularity for latency observations. For
+	// Unit specifies the desired granularity for histogram observations. For
 	// example, an observation of time.Second with a unit of time.Millisecond is
 	// exposed as 1000. Typically, the unit should also be part of the metric
 	// name.
@@ -82,20 +82,20 @@ type HistogramSpec struct {
 }
 
 func (hs HistogramSpec) validateScalar() error {
-	if err := hs.validateLatencies(); err != nil {
+	if err := hs.validateHistogram(); err != nil {
 		return err
 	}
 	return hs.Spec.validateScalar()
 }
 
 func (hs HistogramSpec) validateVector() error {
-	if err := hs.validateLatencies(); err != nil {
+	if err := hs.validateHistogram(); err != nil {
 		return err
 	}
 	return hs.Spec.validateVector()
 }
 
-func (hs HistogramSpec) validateLatencies() error {
+func (hs HistogramSpec) validateHistogram() error {
 	if hs.Unit < 1 {
 		return fmt.Errorf("duration unit must be positive, got %v", hs.Unit)
 	}

--- a/spec_test.go
+++ b/spec_test.go
@@ -356,7 +356,7 @@ func TestHistogramSpecValidation(t *testing.T) {
 			if tt.scalarOK {
 				assertScalarHistogramSpecOK(t, tt.spec)
 			} else {
-				assertSimpleHistogramSpecFail(t, tt.spec)
+				assertScalarHistogramSpecFail(t, tt.spec)
 			}
 			if tt.vecOK {
 				assertVectorHistogramSpecOK(t, tt.spec)
@@ -401,20 +401,20 @@ func assertVectorSpecFail(t testing.TB, spec Spec) {
 
 func assertScalarHistogramSpecOK(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().Histogram(spec)
-	assert.NoError(t, err, "Expected success from NewLatencies.")
+	assert.NoError(t, err, "Expected success from NewHistogram.")
 }
 
-func assertSimpleHistogramSpecFail(t testing.TB, spec HistogramSpec) {
+func assertScalarHistogramSpecFail(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().Histogram(spec)
-	assert.Error(t, err, "Expected an error from NewLatencies.")
+	assert.Error(t, err, "Expected an error from NewHistogram.")
 }
 
 func assertVectorHistogramSpecOK(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().HistogramVector(spec)
-	assert.NoError(t, err, "Expected success from NewLatenciesVector.")
+	assert.NoError(t, err, "Expected success from NewHistogramVector.")
 }
 
 func assertVectorHistogramSpecFail(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().HistogramVector(spec)
-	assert.Error(t, err, "Expected an error from NewLatenciesVector.")
+	assert.Error(t, err, "Expected an error from NewHistogramVector.")
 }

--- a/tallypush/tally.go
+++ b/tallypush/tally.go
@@ -57,7 +57,7 @@ func (tp *target) NewHistogram(spec push.HistogramSpec) push.Histogram {
 			buckets[i] = float64(spec.Buckets[i])
 		}
 	}
-	return &latency{
+	return &histogram{
 		Histogram: tp.Tagged(spec.Tags).Histogram(
 			spec.Name,
 			tally.ValueBuckets(buckets),
@@ -86,7 +86,7 @@ func (tg *gauge) Set(value int64) {
 	tg.Update(float64(value))
 }
 
-type latency struct {
+type histogram struct {
 	tally.Histogram
 
 	// lasts keep the last value pushed to tally per histogram bucket.  This
@@ -94,11 +94,11 @@ type latency struct {
 	lasts map[int64]int64
 }
 
-func (tg *latency) Set(bucket int64, total int64) {
-	delta := total - tg.lasts[bucket]
-	tg.lasts[bucket] = total
+func (th *histogram) Set(bucket int64, total int64) {
+	delta := total - th.lasts[bucket]
+	th.lasts[bucket] = total
 
 	for i := int64(0); i < delta; i++ {
-		tg.RecordValue(float64(bucket))
+		th.RecordValue(float64(bucket))
 	}
 }


### PR DESCRIPTION
It's irritating to always specify histogram buckets with a slice
literal; instead, this commit adds a `bucket` package that exports some
helper functions to create and merge buckets. It also exports a function
to construct our default latency buckets for RPCs.