### PR TITLE
More histogram/latencies renaming

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -71,7 +71,7 @@ type HistogramSpec struct {
 	Spec
 
 	// Durations are exposed as simple numbers, not strings or rich objects.
-	// Unit specifies the desired granularity for latency observations. For
+	// Unit specifies the desired granularity for histogram observations. For
 	// example, an observation of time.Second with a unit of time.Millisecond is
 	// exposed as 1000. Typically, the unit should also be part of the metric
 	// name.
@@ -82,20 +82,20 @@ type HistogramSpec struct {
 }
 
 func (hs HistogramSpec) validateScalar() error {
-	if err := hs.validateLatencies(); err != nil {
+	if err := hs.validateHistogram(); err != nil {
 		return err
 	}
 	return hs.Spec.validateScalar()
 }
 
 func (hs HistogramSpec) validateVector() error {
-	if err := hs.validateLatencies(); err != nil {
+	if err := hs.validateHistogram(); err != nil {
 		return err
 	}
 	return hs.Spec.validateVector()
 }
 
-func (hs HistogramSpec) validateLatencies() error {
+func (hs HistogramSpec) validateHistogram() error {
 	if hs.Unit < 1 {
 		return fmt.Errorf("duration unit must be positive, got %v", hs.Unit)
 	}

--- a/spec_test.go
+++ b/spec_test.go
@@ -356,7 +356,7 @@ func TestHistogramSpecValidation(t *testing.T) {
 			if tt.scalarOK {
 				assertScalarHistogramSpecOK(t, tt.spec)
 			} else {
-				assertSimpleHistogramSpecFail(t, tt.spec)
+				assertScalarHistogramSpecFail(t, tt.spec)
 			}
 			if tt.vecOK {
 				assertVectorHistogramSpecOK(t, tt.spec)
@@ -401,20 +401,20 @@ func assertVectorSpecFail(t testing.TB, spec Spec) {
 
 func assertScalarHistogramSpecOK(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().Histogram(spec)
-	assert.NoError(t, err, "Expected success from NewLatencies.")
+	assert.NoError(t, err, "Expected success from NewHistogram.")
 }
 
-func assertSimpleHistogramSpecFail(t testing.TB, spec HistogramSpec) {
+func assertScalarHistogramSpecFail(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().Histogram(spec)
-	assert.Error(t, err, "Expected an error from NewLatencies.")
+	assert.Error(t, err, "Expected an error from NewHistogram.")
 }
 
 func assertVectorHistogramSpecOK(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().HistogramVector(spec)
-	assert.NoError(t, err, "Expected success from NewLatenciesVector.")
+	assert.NoError(t, err, "Expected success from NewHistogramVector.")
 }
 
 func assertVectorHistogramSpecFail(t testing.TB, spec HistogramSpec) {
 	_, err := New().Scope().HistogramVector(spec)
-	assert.Error(t, err, "Expected an error from NewLatenciesVector.")
+	assert.Error(t, err, "Expected an error from NewHistogramVector.")
 }

--- a/tallypush/tally.go
+++ b/tallypush/tally.go
@@ -57,7 +57,7 @@ func (tp *target) NewHistogram(spec push.HistogramSpec) push.Histogram {
 			buckets[i] = float64(spec.Buckets[i])
 		}
 	}
-	return &latency{
+	return &histogram{
 		Histogram: tp.Tagged(spec.Tags).Histogram(
 			spec.Name,
 			tally.ValueBuckets(buckets),
@@ -86,7 +86,7 @@ func (tg *gauge) Set(value int64) {
 	tg.Update(float64(value))
 }
 
-type latency struct {
+type histogram struct {
 	tally.Histogram
 
 	// lasts keep the last value pushed to tally per histogram bucket.  This
@@ -94,11 +94,11 @@ type latency struct {
 	lasts map[int64]int64
 }
 
-func (tg *latency) Set(bucket int64, total int64) {
-	delta := total - tg.lasts[bucket]
-	tg.lasts[bucket] = total
+func (th *histogram) Set(bucket int64, total int64) {
+	delta := total - th.lasts[bucket]
+	th.lasts[bucket] = total
 
 	for i := int64(0); i < delta; i++ {
-		tg.RecordValue(float64(bucket))
+		th.RecordValue(float64(bucket))
 	}
 }


### PR DESCRIPTION
Clean up some internal methods and types that still reference the old
"latencies" nomenclature for histograms.