### PR TITLE
Add RELEASE.md and verifyversion func

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v1.0.1-dev (unreleased)
 
-- No changes yet.
+- Updated Version constant
 
 ## v1.0.0 (2017-12-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.1-dev (unreleased)
+
+- No changes yet.
+
 ## v1.0.0 (2017-12-22)
 
 - No changes.

--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,18 @@ cover:
 BENCH ?= .
 bench:
 	@$(foreach pkg,$(PKGS),go test -bench=$(BENCH) -run="^$$" $(BENCH_FLAGS) $(pkg);)
+
+.PHONY: verifyversion
+verifyversion: ## verify the version in the changelog is the same as in version.go
+	$(eval CHANGELOG_VERSION := $(shell grep '^## v[0-9]' CHANGELOG.md | head -n1 | cut -d' ' -f2))
+	$(eval INTHECODE_VERSION := $(shell perl -ne '/^const Version.*"([^"]+)".*$$/ && print "v$$1\n"' version.go))
+	@if [ "$(INTHECODE_VERSION)" = "$(CHANGELOG_VERSION)" ]; then \
+		echo "yarpc-go: $(CHANGELOG_VERSION)"; \
+	elif [ "$(INTHECODE_VERSION)" = "$(CHANGELOG_VERSION)-dev" ]; then \
+		echo "yarpc-go (development): $(INTHECODE_VERSION)"; \
+	else \
+		echo "Version number in version.go does not match CHANGELOG.md"; \
+		echo "version.go: $(INTHECODE_VERSION)"; \
+		echo "CHANGELOG : $(CHANGELOG_VERSION)"; \
+		exit 1; \
+	fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,89 @@
+Release process
+===============
+
+This document outlines how to create a release of net/metrics
+
+1.  Set up some environment variables for use later.
+
+    ```
+    # This is the version being released.
+    VERSION=1.21.0
+    ```
+
+2.  Make sure you have the latest master.
+
+    ```
+    git checkout master
+    git pull
+    ```
+
+3.  Alter the release date in CHANGELOG.md for `$VERSION` using the format
+    `YYYY-MM-DD` and remove the trailing `-dev`, making the latest version
+    match `$VERSION`.
+
+    ```diff
+    -## v1.21.0-dev (unreleased)
+    +## v1.21.0 (2017-10-23)
+    ```
+
+4.  Update the version number in version.go and verify that it matches what is
+    in the changelog.
+
+    ```
+    sed -i '' -e "s/^const Version =.*/const Version = \"$VERSION\"/" version.go
+    make verifyversion
+    ```
+
+5.  Create a commit for the release.
+
+    ```
+    git add version.go CHANGELOG.md
+    git commit -m "Preparing release v$VERSION"
+    ```
+
+6.  Tag and push the release.
+
+    ```
+    git tag -a "v$VERSION" -m "v$VERSION"
+    git push origin master "v$VERSION"
+    ```
+
+7.  Go to <https://github.com/yarpc/metrics/tags> and edit the release notes
+    of the new tag.  Copy the changelog entries for this release int the
+    release notes and set the name of the release to the version number
+    (`v$VERSION`).
+
+8.  Add a placeholder for the next version to CHANGELOG.md.  This is typically
+    one minor version above the version just released.
+
+    ```diff
+    +v1.22.0-dev (unreleased)
+    +------------------------
+    +
+    +-   No changes yet.
+    +
+    +
+     v1.21.0 (2017-10-23)
+     --------------------
+    ```
+
+9.  Update the version number in version.go to the same version.
+
+    ```diff
+    -const Version = "1.21.0"
+    +const Version = "1.22.0-dev"
+    ```
+
+10. Verify the version number matches.
+
+    ```
+    make verifyversion
+    ```
+
+11. Commit and push your changes.
+
+    ```
+    git add CHANGELOG.md version.go
+    git commit -m 'Back to development'
+    git push origin master
+    ```

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package metrics
 
 // Version is the current semantic version, exported for runtime compatibility
 // checks.
-const Version = "1.0.0"
+const Version = "1.0.1-dev"

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package metrics
 
 // Version is the current semantic version, exported for runtime compatibility
 // checks.
-const Version = "1.0.0-rc1"
+const Version = "1.0.0"


### PR DESCRIPTION
  Noticed that the version was currently 1.0.0-rc1 which was the old version of the library.  I've added a Release.md similar to the yarpc one, and a `make verifyversion` func (modified from yarpc) to validate that the versions in the changelog and version var are equivalent.