### PR TITLE
Add type hint to histograms for superior tally integration

### DIFF
--- a/histogram.go
+++ b/histogram.go
@@ -79,15 +79,17 @@ type Histogram struct {
 	bounds   []int64
 	buckets  buckets
 	sum      atomic.Int64 // required by Prometheus
+	hType    HistogramType
 	pusher   push.Histogram
 	tagPairs []*promproto.LabelPair
 }
 
-func newHistogram(m metadata, unit time.Duration, uppers []int64) *Histogram {
+func newHistogram(m metadata, unit time.Duration, uppers []int64, hType HistogramType) *Histogram {
 	return &Histogram{
 		buckets:  newBuckets(uppers),
 		meta:     m,
 		unit:     unit,
+		hType:    hType,
 		bounds:   uppers,
 		tagPairs: m.MergeTags(nil /* variable tag vals */),
 	}
@@ -186,6 +188,7 @@ func (h *Histogram) push(target push.Target) {
 				Tags: zip(h.tagPairs),
 			},
 			Buckets: h.bounds,
+			Type:    push.HistogramType(h.hType),
 		})
 	}
 	for _, bucket := range h.buckets {

--- a/push/push.go
+++ b/push/push.go
@@ -45,11 +45,24 @@ type Spec struct {
 	Tags map[string]string
 }
 
+// HistogramType is a hint for the representation of the histogram when being
+// pushed or viewed.
+type HistogramType int
+
+const (
+	// Value types are float value recorded histograms.
+	Value HistogramType = iota
+	// Duration types are time based histograms.
+	Duration
+)
+
 // A HistogramSpec configures histograms.
 type HistogramSpec struct {
 	Spec
 
 	Buckets []int64 // upper bounds, inclusive
+
+	Type HistogramType
 }
 
 // A Counter models monotonically increasing values, like a car's odometer.

--- a/scope.go
+++ b/scope.go
@@ -103,7 +103,7 @@ func (s *Scope) Histogram(spec HistogramSpec) (*Histogram, error) {
 	if err != nil {
 		return nil, err
 	}
-	h := newHistogram(meta, spec.Unit, spec.Buckets)
+	h := newHistogram(meta, spec.Unit, spec.Buckets, spec.Type)
 	if err := s.core.register(h); err != nil {
 		return nil, err
 	}

--- a/spec.go
+++ b/spec.go
@@ -66,6 +66,17 @@ func (s Spec) validateVector() error {
 	return nil
 }
 
+// HistogramType is a hint for the representation of the histogram when being
+// pushed or viewed.
+type HistogramType int
+
+const (
+	// Value types are float value recorded histograms.
+	Value HistogramType = iota
+	// Duration types are time based histograms.
+	Duration
+)
+
 // A HistogramSpec configures Histograms and HistogramVectors.
 type HistogramSpec struct {
 	Spec
@@ -80,6 +91,9 @@ type HistogramSpec struct {
 	// A catch-all bucket for large observations is automatically created, if
 	// necessary.
 	Buckets []int64
+	// Represents the types of values that are being recorded on this histogram.
+	// Defaults to "Value"
+	Type HistogramType
 }
 
 func (hs HistogramSpec) validateScalar() error {
@@ -97,6 +111,9 @@ func (hs HistogramSpec) validateVector() error {
 }
 
 func (hs HistogramSpec) validateHistogram() error {
+	if int(hs.Type) > 1 || int(hs.Type) < 0 {
+		return fmt.Errorf("histogram type must be one of value or duration, got: %v", hs.Type)
+	}
 	if hs.Unit < 1 {
 		return fmt.Errorf("duration unit must be positive, got %v", hs.Unit)
 	}

--- a/spec_test.go
+++ b/spec_test.go
@@ -349,6 +349,22 @@ func TestHistogramSpecValidation(t *testing.T) {
 			scalarOK: false,
 			vecOK:    false,
 		},
+		{
+			desc: "valid everything, invalid histogram type",
+			spec: HistogramSpec{
+				Spec: Spec{
+					Name:      "foo",
+					Help:      "Some help.",
+					ConstTags: Tags{"foo": "bar"},
+					VarTags:   []string{"baz"},
+				},
+				Unit:    time.Millisecond,
+				Buckets: []int64{60, 1000},
+				Type:    HistogramType(123),
+			},
+			scalarOK: false,
+			vecOK:    false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Summary: Currently, all histograms created through netmetrics will
always be recorded as values.  This mostly affects the bucket name tags
that are recorded with the histograms.  Currently, the histograms are
being recorded as "1.00000-2.00000" where ideally they would be
"1ms-2ms".

This PR keeps the "Value" as the default for histograms, but adds a Type
field to the HistogramSpec that we thread through to the
push.HistogramSpec so that our tally integration can do the right thing
based on the type of histogram.

Biggest part of this PR that's iffy for me is the repeated const values
in the metrics and push packages, open to suggestions to isolate that.