### PR TITLE
Prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-## v1.1.0-dev (unreleased)
+## v1.1.0
 
-- No changes yet.
+- Update pinned version of Prometheus.
 
 ## v1.0.1 (2018-01-04)
 

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package metrics
 
 // Version is the current semantic version, exported for runtime compatibility
 // checks.
-const Version = "1.1.0-dev"
+const Version = "1.1.0"


### PR DESCRIPTION
Updating Prometheus is (arguably) a user-facing change, since it affects
their ability to update depdendencies. Regardless, we need to cut a new
release so users can pull in the new constraints.