### PR TITLE
Back to development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,26 @@
 # Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+- No changes yet.
 
 ## v1.1.0
-
+### Changed
 - Update pinned version of Prometheus.
 
 ## v1.0.1 (2018-01-04)
-
+### Fixed
 - Updated Version constant.
 
 ## v1.0.0 (2017-12-22)
-
 - No changes.
 
 ## v1.0.0-rc2 (2017-12-20)
-
+### Fixed
 - Fix a bug exposing zero-length vectors over HTTP.
 
 ## v1.0.0-rc1 (2017-12-11)
-
 - Initial public release.

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package metrics
 
 // Version is the current semantic version, exported for runtime compatibility
 // checks.
-const Version = "1.1.0"
+const Version = "1.2.0-dev"


### PR DESCRIPTION
Update the changelog and version constant to go back to development.
Along the way, migrate to the KAC format.