### PR TITLE
Preparing version v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-### Fixed
+## v1.2.0
+### Changed
 - Support Prometheus client 1.X.
 
 ## v1.1.0

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package metrics
 
 // Version is the current semantic version, exported for runtime compatibility
 // checks.
-const Version = "1.2.0-dev"
+const Version = "1.2.0"


### PR DESCRIPTION
This releases v1.2.0 with the loosened prometheus/client_golang constraint.