### PR TITLE
Fix histogram prometheus exported cumulative counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v1.3.1 (2021-09-22)
+- Fix cumulative counts of histogram buckets in prometheus metrics export.
+
 ## v1.3.0 (2020-01-21)
 - Migrate to Go modules.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased (2021-09-22)
+## v1.3.1-dev (unreleased)
 - Fix cumulative counts of histogram buckets in prometheus metrics export.
 
 ## v1.3.0 (2020-01-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## v1.3.1 (2021-09-22)
+## Unreleased (2021-09-22)
 - Fix cumulative counts of histogram buckets in prometheus metrics export.
 
 ## v1.3.0 (2020-01-21)

--- a/histogram.go
+++ b/histogram.go
@@ -157,9 +157,10 @@ func (h *Histogram) metric() *promproto.Metric {
 			// Prometheus doesn't want us to export the final catch-all bucket.
 			continue
 		}
+		cumulativeCount := n
 		upper := float64(b.upper)
 		promBuckets = append(promBuckets, &promproto.Bucket{
-			CumulativeCount: &n,
+			CumulativeCount: &cumulativeCount,
 			UpperBound:      &upper,
 		})
 	}

--- a/version.go
+++ b/version.go
@@ -22,4 +22,4 @@ package metrics
 
 // Version is the current semantic version, exported for runtime compatibility
 // checks.
-const Version = "1.3.0"
+const Version = "1.3.1-dev"


### PR DESCRIPTION
Currently, histogram bucket cumulative values exported are incorrect due to referencing the same counter (pointer) across different buckets. For example, let's you have three buckets and each has one sample:
```
[0-10] - 1
[10-20] - 1
[20-30] - 1
```

Currently, the above buckets are exported with incorrect cumulative counts:
```
# prometheus exported counts
cumulative_count:3 upperbound:10
cumulative_count:3 upperbound:20
cumulative_count:3 upperbound:30
```

This PR fixes the cumulative count:
```
# prometheus exported counts
cumulative_count:1 upperbound:10
cumulative_count:2 upperbound:20
cumulative_count:3 upperbound:30
```

