### PR TITLE
Improve histogram push

### DIFF
--- a/histogram.go
+++ b/histogram.go
@@ -189,8 +189,8 @@ func (h *Histogram) push(target push.Target) {
 			Buckets: h.bounds,
 		})
 	}
-	for _, bucket := range h.buckets {
-		h.pusher.Set(bucket.upper, bucket.Load())
+	for index, bucket := range h.buckets {
+		h.pusher.SetIndex(index, bucket.upper, bucket.Load())
 	}
 }
 

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -28,6 +28,9 @@ import (
 	promproto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+	bucketpkg "go.uber.org/net/metrics/bucket"
+	"go.uber.org/net/metrics/tallypush"
 )
 
 func uint64ptr(i uint64) *uint64 {
@@ -260,4 +263,17 @@ func TestHistogramVectorIndependence(t *testing.T) {
 		Unit:   time.Millisecond,
 		Values: []int64{1000},
 	}, snap.Histograms[1], "Unexpected second histogram snapshot.")
+}
+
+func BenchmarkHistogram(b *testing.B) {
+	pusher := tallypush.New(tally.NoopScope)
+	name := ""
+	hist := newHistogram(metadata{
+		Name: &name,
+	}, time.Millisecond, bucketpkg.NewRPCLatency())
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		hist.push(pusher)
+	}
 }

--- a/push/nop.go
+++ b/push/nop.go
@@ -32,4 +32,6 @@ func (n *nop) Set(int64)                            {}
 
 type nopHistogram struct{}
 
+func (h *nopHistogram) SetIndex(int, int64, int64) {}
+
 func (h *nopHistogram) Set(int64, int64) {}

--- a/push/push.go
+++ b/push/push.go
@@ -77,4 +77,5 @@ type Gauge interface {
 // Implementations do not need to be safe for concurrent use.
 type Histogram interface {
 	Set(bucket int64, total int64)
+	SetIndex(bucketIndex int, bucket int64, total int64)
 }


### PR DESCRIPTION
Iterating an array to access a map for every element is expensive. Therefore, use a slice internally. The old API would be slower (~27%), but the new API is 4.09x faster. This way we are able to support any library that could be using it, but internally we use the new API to get the benefits from it.

Original
<img width="513" alt="Screenshot 2023-06-12 at 7 47 25 PM" src="https://github.com/yarpc/metrics/assets/3793727/59eb7408-a4ec-426b-9092-a20174ca41bd">

New (Old API)
<img width="512" alt="Screenshot 2023-06-12 at 7 44 50 PM" src="https://github.com/yarpc/metrics/assets/3793727/6d52fb64-dff9-4c2c-8b13-69e431fb12e8">

New (Fast API)

<img width="529" alt="Screenshot 2023-06-13 at 9 43 30 AM" src="https://github.com/yarpc/metrics/assets/3793727/ab85e067-54da-476f-b23d-b792bf337bb6">
