### PR TITLE
Feature/improve metric pushing

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -124,9 +124,10 @@ type CounterVector struct {
 
 func newCounterVector(m metadata) *CounterVector {
 	return &CounterVector{vector{
-		meta:    m,
-		factory: newDynamicCounter,
-		metrics: make(map[string]metric, _defaultCollectionSize),
+		meta:           m,
+		factory:        newDynamicCounter,
+		metrics:        make(map[string]uint32, _defaultCollectionSize),
+		metricsStorage: make([]metric, 0, _defaultCollectionSize),
 	}}
 }
 
@@ -171,7 +172,7 @@ func (cv *CounterVector) proto() *promproto.MetricFamily {
 	}
 	cv.metricsMu.RLock()
 	protos := make([]*promproto.Metric, 0, len(cv.metrics))
-	for _, metric := range cv.metrics {
+	for _, metric := range cv.metricsStorage {
 		protos = append(protos, metric.(*Counter).metric())
 	}
 	cv.metricsMu.RUnlock()

--- a/gauge.go
+++ b/gauge.go
@@ -157,9 +157,10 @@ type GaugeVector struct {
 
 func newGaugeVector(m metadata) *GaugeVector {
 	return &GaugeVector{vector{
-		meta:    m,
-		factory: newDynamicGauge,
-		metrics: make(map[string]metric, _defaultCollectionSize),
+		meta:           m,
+		factory:        newDynamicGauge,
+		metrics:        make(map[string]uint32, _defaultCollectionSize),
+		metricsStorage: make([]metric, 0, _defaultCollectionSize),
 	}}
 }
 
@@ -204,7 +205,7 @@ func (gv *GaugeVector) proto() *promproto.MetricFamily {
 	}
 	gv.metricsMu.RLock()
 	protos := make([]*promproto.Metric, 0, len(gv.metrics))
-	for _, metric := range gv.metrics {
+	for _, metric := range gv.metricsStorage {
 		protos = append(protos, metric.(*Gauge).metric())
 	}
 	gv.metricsMu.RUnlock()

--- a/value_test.go
+++ b/value_test.go
@@ -1,0 +1,55 @@
+package metrics
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+
+	"github.com/uber-go/tally"
+	"go.uber.org/net/metrics/tallypush"
+)
+
+func BenchmarkValueVector(b *testing.B) {
+	b.Run("getOrCreate", func(b *testing.B) {
+		vect := newCounterVector(metadata{varTagNames: []string{"key"}})
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_, err := vect.getOrCreate([]string{"key", fmt.Sprint("val", i)})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("get", func(b *testing.B) {
+		vect := newCounterVector(metadata{varTagNames: []string{"key"}})
+		_, err := vect.getOrCreate([]string{"key", "val0"})
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			runtime.KeepAlive(vect.MustGet("key", "val0"))
+		}
+	})
+
+	const _loopLimit = 10_000
+	b.Run(fmt.Sprint("loop", _loopLimit), func(b *testing.B) {
+		name := ""
+		vect := newCounterVector(metadata{Name: &name, varTagNames: []string{"key"}})
+		for i := 0; i < _loopLimit; i++ {
+			_, err := vect.getOrCreate([]string{"key", fmt.Sprint("val", i)})
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+		pusher := tallypush.New(tally.NoopScope)
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			vect.push(pusher)
+		}
+	})
+}


### PR DESCRIPTION
Depends on #38 

TLDR; 
- getOrCreate is >45% faster.
- get is the same.
- Loop over 10k metrics is >3.25x faster.

The only limitation is that we can't store more than 4 Billion metrics per vector, but my guess is that it should be enough.

Additionally this is going to increase memory usage because now we are saving 4 additional bytes per metric. Considering a considerable usage of 1 Million metrics, this is only 4MB, so I think we are still good on this front.

Old
<img width="756" alt="Screenshot 2023-06-12 at 8 23 30 PM" src="https://github.com/yarpc/metrics/assets/3793727/181df288-04c1-4613-9517-9950941832bf">

New
<img width="761" alt="Screenshot 2023-06-12 at 8 55 43 PM" src="https://github.com/yarpc/metrics/assets/3793727/e20f64f2-5a8b-4570-a044-61d40ad760bb">

